### PR TITLE
Add prompt management system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
+import { AdminProvider } from './context/AdminContext';
 import { WizardProvider } from './context/WizardContext';
 import { useAuth } from './context/AuthContext';
 import Wizard from './components/Wizard/Wizard';
@@ -13,6 +14,7 @@ import CharactersGrid from './components/Character/CharactersGrid';
 import NotificationBell from './components/Notifications/NotificationBell';
 import ToastContainer from './components/UI/ToastContainer';
 import ProfileSettings from './pages/ProfileSettings';
+import PromptManager from './pages/Admin/PromptManager';
 import { useProfileStore } from './stores/profileStore';
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
@@ -88,6 +90,14 @@ function AppContent() {
                   </PrivateRoute>
                 }
               />
+              <Route
+                path="/admin/prompts"
+                element={
+                  <PrivateRoute>
+                    <PromptManager />
+                  </PrivateRoute>
+                }
+              />
             </Routes>
           </main>
           <footer className="py-4 text-center text-purple-600 text-sm">
@@ -133,7 +143,9 @@ function App() {
   return (
     <Router>
       <AuthProvider>
-        <AppContent />
+        <AdminProvider>
+          <AppContent />
+        </AdminProvider>
       </AuthProvider>
     </Router>
   );

--- a/src/components/Admin/PromptEditor.tsx
+++ b/src/components/Admin/PromptEditor.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+interface Props {
+  initialType?: string;
+  initialContent?: string;
+  onSave: (type: string, content: string) => void;
+}
+
+const PromptEditor: React.FC<Props> = ({ initialType = '', initialContent = '', onSave }) => {
+  const [type, setType] = useState(initialType);
+  const [content, setContent] = useState(initialContent);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!type || !content) return;
+    onSave(type, content);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Tipo</label>
+        <input
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="mt-1 w-full border rounded px-2 py-1 text-sm"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700">Contenido</label>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={6}
+          className="mt-1 w-full border rounded px-2 py-1 text-sm"
+        />
+      </div>
+      <button type="submit" className="px-4 py-2 bg-purple-600 text-white rounded">
+        Guardar
+      </button>
+    </form>
+  );
+};
+
+export default PromptEditor;

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,20 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { BookOpen, User, Settings, LogOut, AlertTriangle } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
+import { useAdmin } from '../../context/AdminContext';
 import { Link } from 'react-router-dom';
 import { ImageGenerationSettings, ImageEngine, OpenAIModel, StabilityModel } from '../../types';
 
 const Sidebar: React.FC = () => {
-  const { signOut, user, supabase } = useAuth();
-  const [isAdmin, setIsAdmin] = useState(false);
+  const { signOut, supabase } = useAuth();
+  const isAdmin = useAdmin();
   const [settings, setSettings] = useState<ImageGenerationSettings | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const checkAdminStatus = () => {
-      setIsAdmin(user?.email === 'fabarca212@gmail.com');
-    };
-
     const loadSettings = async () => {
       if (!isAdmin) return;
       
@@ -32,9 +29,8 @@ const Sidebar: React.FC = () => {
       }
     };
 
-    checkAdminStatus();
     loadSettings();
-  }, [user, supabase, isAdmin]);
+  }, [supabase, isAdmin]);
 
   const handleEngineChange = async (
     type: 'thumbnail' | 'variations' | 'spriteSheet',
@@ -174,6 +170,14 @@ const Sidebar: React.FC = () => {
               <span>Mi Perfil</span>
             </Link>
           </li>
+          {isAdmin && (
+            <li>
+              <Link to="/admin/prompts" className="flex items-center gap-3 px-4 py-2 text-gray-700 hover:bg-purple-50 rounded-lg dark:text-gray-300 dark:hover:bg-purple-900/20">
+                <Settings className="w-5 h-5" />
+                <span>Prompts</span>
+              </Link>
+            </li>
+          )}
           {isAdmin && (
             <li className="mt-4">
               <div className="px-4 py-2">

--- a/src/context/AdminContext.tsx
+++ b/src/context/AdminContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import { useAuth } from './AuthContext';
+
+const ADMIN_EMAILS = [
+  'fabarca212@gmail.com',
+  'lucianoalonso2000@gmail.com',
+  'javier2000asr@gmail.com'
+];
+
+const AdminContext = createContext<boolean>(false);
+
+export const AdminProvider = ({ children }: { children: React.ReactNode }) => {
+  const { user } = useAuth();
+  const isAdmin = !!user && ADMIN_EMAILS.includes(user.email ?? '');
+  return <AdminContext.Provider value={isAdmin}>{children}</AdminContext.Provider>;
+};
+
+export const useAdmin = () => useContext(AdminContext);

--- a/src/hooks/usePromptManager.ts
+++ b/src/hooks/usePromptManager.ts
@@ -1,0 +1,47 @@
+import { useState, useCallback, useEffect } from 'react';
+import { promptService, Prompt } from '../services/promptService';
+import { useAdmin } from '../context/AdminContext';
+
+export const usePromptManager = () => {
+  const isAdmin = useAdmin();
+  const [prompts, setPrompts] = useState<Prompt[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPrompts = useCallback(async () => {
+    if (!isAdmin) return;
+    setLoading(true);
+    try {
+      const data = await promptService.fetchPrompts();
+      setPrompts(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [isAdmin]);
+
+  const savePrompt = useCallback(async (type: string, content: string) => {
+    if (!isAdmin) return null;
+    try {
+      const updated = await promptService.upsertPrompt(type, content);
+      setPrompts(prev => {
+        const exists = prev.find(p => p.type === updated.type);
+        if (exists) {
+          return prev.map(p => (p.type === updated.type ? updated : p));
+        }
+        return [...prev, updated];
+      });
+      return updated;
+    } catch (err) {
+      setError((err as Error).message);
+      return null;
+    }
+  }, [isAdmin]);
+
+  useEffect(() => {
+    loadPrompts();
+  }, [loadPrompts]);
+
+  return { prompts, loadPrompts, savePrompt, loading, error };
+};

--- a/src/pages/Admin/PromptManager.tsx
+++ b/src/pages/Admin/PromptManager.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { usePromptManager } from '../../hooks/usePromptManager';
+import PromptEditor from '../../components/Admin/PromptEditor';
+import { useAdmin } from '../../context/AdminContext';
+
+const PromptManager: React.FC = () => {
+  const { prompts, savePrompt, loading, error } = usePromptManager();
+  const isAdmin = useAdmin();
+
+  if (!isAdmin) {
+    return <p>No autorizado</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Gestión de Prompts</h1>
+      {loading && <p>Cargando...</p>}
+      {error && <p className="text-red-500">{error}</p>}
+      <div className="space-y-4">
+        {prompts.map((p) => (
+          <div key={p.id} className="border p-4 rounded">
+            <h3 className="font-semibold mb-2">{p.type}</h3>
+            <PromptEditor
+              initialType={p.type}
+              initialContent={p.content}
+              onSave={(type, content) => savePrompt(type, content)}
+            />
+          </div>
+        ))}
+      </div>
+      <div className="mt-8 border-t pt-4">
+        <h2 className="font-semibold mb-2">Nuevo prompt</h2>
+        <PromptEditor onSave={(type, content) => savePrompt(type, content)} />
+      </div>
+    </div>
+  );
+};
+
+export default PromptManager;

--- a/src/services/promptService.ts
+++ b/src/services/promptService.ts
@@ -1,0 +1,44 @@
+import { supabase } from '../lib/supabase';
+
+export interface Prompt {
+  id: string;
+  type: string;
+  content: string;
+  version: number;
+  updated_at: string;
+}
+
+export const promptService = {
+  async fetchPrompts(): Promise<Prompt[]> {
+    const { data, error } = await supabase
+      .from('prompts')
+      .select('*')
+      .order('type');
+    if (error) throw error;
+    return data as Prompt[];
+  },
+
+  async getPrompt(type: string): Promise<Prompt | null> {
+    const { data, error } = await supabase
+      .from('prompts')
+      .select('*')
+      .eq('type', type)
+      .single();
+    if (error && error.code !== 'PGRST116') throw error;
+    return data as Prompt | null;
+  },
+
+  async upsertPrompt(type: string, content: string): Promise<Prompt> {
+    const { data, error } = await supabase
+      .from('prompts')
+      .upsert({ type, content })
+      .select('*')
+      .single();
+    if (error) throw error;
+    return data as Prompt;
+  },
+
+  async revertPrompt(id: string, version: number): Promise<void> {
+    await supabase.rpc('revert_prompt_version', { p_id: id, p_version: version });
+  }
+};

--- a/supabase/migrations/20250525_create_prompts_table.sql
+++ b/supabase/migrations/20250525_create_prompts_table.sql
@@ -1,0 +1,132 @@
+/*
+  # Create prompts table for editable templates
+
+  1. New Tables
+    - prompts
+      - id uuid primary key
+      - type text unique
+      - content text
+      - version integer
+      - updated_at timestamp
+      - updated_by uuid
+    - prompt_versions
+      - id uuid primary key
+      - prompt_id uuid references prompts
+      - version integer
+      - content text
+      - created_at timestamp
+      - created_by uuid
+
+  2. RLS
+    - Only admins may read or modify prompts and versions
+
+  3. Triggers
+    - Auto increment version on update
+    - Log versions on insert/update
+*/
+
+create table if not exists prompts (
+  id uuid primary key default gen_random_uuid(),
+  type text unique not null,
+  content text not null,
+  version integer not null default 1,
+  updated_at timestamptz default now(),
+  updated_by uuid references auth.users(id)
+);
+
+create table if not exists prompt_versions (
+  id uuid primary key default gen_random_uuid(),
+  prompt_id uuid references prompts(id) on delete cascade,
+  version integer not null,
+  content text not null,
+  created_at timestamptz default now(),
+  created_by uuid references auth.users(id)
+);
+
+alter table prompts enable row level security;
+alter table prompt_versions enable row level security;
+
+create policy "Admins read prompts" on prompts
+for select to authenticated
+using (auth.jwt() ->> 'email' in (
+  'fabarca212@gmail.com',
+  'lucianoalonso2000@gmail.com',
+  'javier2000asr@gmail.com'
+));
+
+create policy "Admins modify prompts" on prompts
+for all to authenticated
+using (auth.jwt() ->> 'email' in (
+  'fabarca212@gmail.com',
+  'lucianoalonso2000@gmail.com',
+  'javier2000asr@gmail.com'
+))
+with check (auth.jwt() ->> 'email' in (
+  'fabarca212@gmail.com',
+  'lucianoalonso2000@gmail.com',
+  'javier2000asr@gmail.com'
+));
+
+create policy "Admins read prompt_versions" on prompt_versions
+for select to authenticated
+using (auth.jwt() ->> 'email' in (
+  'fabarca212@gmail.com',
+  'lucianoalonso2000@gmail.com',
+  'javier2000asr@gmail.com'
+));
+
+create policy "Admins insert prompt_versions" on prompt_versions
+for insert to authenticated
+with check (auth.jwt() ->> 'email' in (
+  'fabarca212@gmail.com',
+  'lucianoalonso2000@gmail.com',
+  'javier2000asr@gmail.com'
+));
+
+create or replace function update_prompt_version()
+returns trigger as $$
+begin
+  new.version := coalesce(old.version,1) + 1;
+  new.updated_at := now();
+  return new;
+end;
+$$ language plpgsql;
+
+create or replace function log_prompt_version()
+returns trigger as $$
+begin
+  insert into prompt_versions(prompt_id, version, content, created_by)
+  values(new.id, new.version, new.content, new.updated_by);
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_update_prompt_version
+before update on prompts
+for each row execute function update_prompt_version();
+
+create trigger trg_log_prompt_version
+after insert or update on prompts
+for each row execute function log_prompt_version();
+
+create or replace function revert_prompt_version(p_id uuid, p_version integer)
+returns void as $$
+declare
+  v_content text;
+begin
+  select content into v_content
+  from prompt_versions
+  where prompt_id = p_id and version = p_version
+  order by created_at desc limit 1;
+  if v_content is null then
+    raise exception 'Version not found';
+  end if;
+  update prompts
+  set content = v_content,
+      version = p_version,
+      updated_at = now()
+  where id = p_id;
+end;
+$$ language plpgsql security definer;
+
+grant execute on function revert_prompt_version(uuid, integer) to authenticated;


### PR DESCRIPTION
## Summary
- create AdminContext to detect admin emails
- add PromptManager admin page and editor component
- handle prompts via new promptService and usePromptManager hook
- load prompts from DB in describe-and-sketch and analyze-character functions
- add prompts table migration with RLS and triggers
- wire AdminProvider in App and show admin link in Sidebar

## Testing
- `npm run lint` *(fails: many existing lint errors)*