### PR TITLE
Add Supabase sync guide and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Plataforma web interactiva para crear cuentos infantiles personalizados con ilus
 - [📊 Flujo de Usuario](#-flujo-de-usuario)
 - [🔧 Contextos](#-contextos)
 - [🖼️ Imágenes de Respaldo](#-imágenes-de-respaldo)
+- [🔄 Sincronización Supabase](#-sincronización-supabase)
 - [🤝 Contribución](#-contribución)
 - [📄 Licencia](#-licencia)
 - [✨ Créditos](#-créditos)
@@ -218,6 +219,10 @@ El proyecto utiliza imágenes genéricas de respaldo para cada estilo visual cua
 - **Kawaii**: `supabase/storage/fallback-images/kawaii.webp`
 
 Estas imágenes se encuentran en Supabase Storage en la carpeta `fallback-images/`. Para más detalles sobre cómo generar y utilizar estas imágenes, consulta la [guía de imágenes de respaldo](docs/fallback_images_guide.md).
+
+## 🔄 Sincronización Supabase
+
+Si se realizaron cambios directamente en el dashboard de Supabase y no están reflejados en el repositorio local, consulta el documento [Sincronización de Cambios en Supabase](docs/tech/supabase-sync.md) para obtener los pasos necesarios y evitar conflictos de migración.
 
 ## 🤝 Contribución
 

--- a/docs/tech/supabase-sync.md
+++ b/docs/tech/supabase-sync.md
@@ -1,0 +1,53 @@
+# 🔄 Sincronización de Cambios en Supabase
+
+Este documento describe el proceso recomendado para mantener el código local sincronizado con los cambios realizados en el proyecto de Supabase. Si en algún momento se modifican funciones Edge o el esquema de la base de datos directamente desde el dashboard de Supabase, sigue estos pasos para reflejar esas actualizaciones en el repositorio.
+
+## 1. Preparación
+
+1. Instala la CLI de Supabase (si aún no la tienes):
+
+   ```bash
+   npm install -g supabase
+   ```
+
+2. Inicia sesión en la CLI:
+
+   ```bash
+   supabase login
+   ```
+
+3. Enlaza tu proyecto local con el proyecto remoto (solo es necesario la primera vez):
+
+   ```bash
+   supabase link --project-ref <tu-project-ref>
+   ```
+
+## 2. Obtener los cambios desde Supabase
+
+Ejecuta el script proporcionado en `package.json` para descargar las funciones Edge y el esquema actualizado:
+
+```bash
+npm run supabase:pull
+```
+
+Esto ejecuta internamente `supabase functions pull` y `supabase db pull`, lo que actualiza las carpetas `supabase/functions/` y `supabase/migrations/` con lo que existe en el proyecto remoto.
+
+## 3. Verificar el entorno local
+
+1. Inicia los servicios locales para comprobar que todo funciona:
+
+   ```bash
+   npm run supabase:start
+   ```
+
+2. Revisa que las migraciones se apliquen sin conflictos y que las funciones Edge se ejecuten correctamente.
+
+## 4. Flujo de trabajo recomendado
+
+- Evita hacer cambios directamente en el dashboard de Supabase. Siempre que sea posible, realiza modificaciones desde el entorno local y súbelas mediante migraciones y funciones versionadas.
+- Si necesitas hacer un ajuste rápido en producción, documenta el cambio y sincroniza el repositorio siguiendo esta guía inmediatamente después.
+- Considera implementar pruebas automatizadas que comparen el esquema local con el remoto para detectar diferencias inesperadas.
+
+---
+
+Siguiendo estos pasos se mantendrá la coherencia entre el repositorio local y el entorno de Supabase, reduciendo los problemas al ejecutar migraciones o desplegar nuevas versiones.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "test:e2e": "cypress run"
+    "test:e2e": "cypress run",
+    "supabase:pull": "supabase functions pull && supabase db pull",
+    "supabase:start": "supabase start"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.8",


### PR DESCRIPTION
## Summary
- add npm scripts `supabase:pull` and `supabase:start`
- document how to synchronize local changes with Supabase
- reference the new guide in README

## Testing
- `supabase --version` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*