### PR TITLE
feat: add edit/delete controls in character modal

### DIFF
--- a/src/components/Character/CharacterCard.tsx
+++ b/src/components/Character/CharacterCard.tsx
@@ -65,7 +65,10 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
           <div className="flex gap-2">
             {onEdit && (
               <button
-                onClick={() => onEdit(character.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit(character.id);
+                }}
                 className="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-purple-600 hover:bg-purple-50 rounded-md transition-colors"
               >
                 <Edit2 className="w-4 h-4" />
@@ -74,7 +77,10 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
             )}
             {onDelete && (
               <button
-                onClick={() => onDelete(character.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(character.id);
+                }}
                 className="flex-1 flex items-center justify-center gap-2 px-3 py-2 text-red-600 hover:bg-red-50 rounded-md transition-colors"
               >
                 <Trash2 className="w-4 h-4" />

--- a/src/components/Character/CharacterForm.tsx
+++ b/src/components/Character/CharacterForm.tsx
@@ -12,11 +12,14 @@ import { Character } from '../../types';
 interface CharacterFormProps {
   onSave?: (id: string) => void;
   onCancel?: () => void;
+  /** ID del personaje a editar. Si no se proporciona se lee desde la ruta */
+  id?: string;
 }
 
-const CharacterForm: React.FC<CharacterFormProps> = ({ onSave, onCancel }) => {
+const CharacterForm: React.FC<CharacterFormProps> = ({ onSave, onCancel, id: propId }) => {
   const navigate = useNavigate();
-  const { id } = useParams<{ id: string }>();
+  const { id: routeId } = useParams<{ id: string }>();
+  const id = propId || routeId;
   const { supabase, user } = useAuth();
   const { addCharacter, updateCharacter } = useCharacterStore();
   const { createNotification } = useNotifications();


### PR DESCRIPTION
## Summary
- allow CharacterForm to accept an id prop so it can be used in a modal
- stop event propagation on CharacterCard action buttons
- enhance CharacterSelectionModal with edit and delete actions

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`
- `npm run test:e2e` *(fails: missing Xvfb)*