### PR TITLE
Add prompt metrics infrastructure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import NotificationBell from './components/Notifications/NotificationBell';
 import ToastContainer from './components/UI/ToastContainer';
 import ProfileSettings from './pages/ProfileSettings';
 import PromptManager from './pages/Admin/PromptManager';
+import PromptAnalytics from './pages/Admin/Analytics/PromptAnalytics';
 import { useProfileStore } from './stores/profileStore';
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
@@ -95,6 +96,14 @@ function AppContent() {
                 element={
                   <PrivateRoute>
                     <PromptManager />
+                  </PrivateRoute>
+                }
+              />
+              <Route
+                path="/admin/analytics"
+                element={
+                  <PrivateRoute>
+                    <PromptAnalytics />
                   </PrivateRoute>
                 }
               />

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { BookOpen, User, Settings, LogOut, AlertTriangle } from 'lucide-react';
+import { BookOpen, User, Settings, LogOut, AlertTriangle, BarChart3 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { useAdmin } from '../../context/AdminContext';
 import { Link } from 'react-router-dom';
@@ -175,6 +175,14 @@ const Sidebar: React.FC = () => {
               <Link to="/admin/prompts" className="flex items-center gap-3 px-4 py-2 text-gray-700 hover:bg-purple-50 rounded-lg dark:text-gray-300 dark:hover:bg-purple-900/20">
                 <Settings className="w-5 h-5" />
                 <span>Prompts</span>
+              </Link>
+            </li>
+          )}
+          {isAdmin && (
+            <li>
+              <Link to="/admin/analytics" className="flex items-center gap-3 px-4 py-2 text-gray-700 hover:bg-purple-50 rounded-lg dark:text-gray-300 dark:hover:bg-purple-900/20">
+                <BarChart3 className="w-5 h-5" />
+                <span>Analytics</span>
               </Link>
             </li>
           )}

--- a/src/pages/Admin/Analytics/PromptAnalytics.tsx
+++ b/src/pages/Admin/Analytics/PromptAnalytics.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useAdmin } from '../../../context/AdminContext';
+
+const PromptAnalytics: React.FC = () => {
+  const isAdmin = useAdmin();
+
+  if (!isAdmin) {
+    return <p>No autorizado</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Análisis de Prompts</h1>
+      <p className="text-sm text-gray-600">Próximamente se mostrarán las métricas de rendimiento.</p>
+    </div>
+  );
+};
+
+export default PromptAnalytics;

--- a/src/services/metrics/__tests__/promptMetricsService.test.ts
+++ b/src/services/metrics/__tests__/promptMetricsService.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { promptMetricsService } from '../promptMetricsService';
+
+const insert = vi.fn();
+const select = vi.fn();
+const single = vi.fn();
+const order = vi.fn();
+const eq = vi.fn();
+const chain = { insert, select, single, order, eq };
+const from = vi.fn(() => chain);
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from }
+}));
+
+
+describe('promptMetricsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logMetric inserts metric and returns created record', async () => {
+    const mockData = { id: '1' };
+    single.mockResolvedValue({ data: mockData, error: null });
+    const result = await promptMetricsService.logMetric({
+      prompt_id: 'p',
+      modelo_ia: 'gpt',
+      tiempo_respuesta_ms: 10,
+      estado: 'success',
+      tokens_entrada: 1,
+      tokens_salida: 2,
+    });
+    expect(from).toHaveBeenCalledWith('prompt_metrics');
+    expect(insert).toHaveBeenCalled();
+    expect(select).toHaveBeenCalled();
+    expect(single).toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+  });
+
+  it('fetchMetrics returns list', async () => {
+    const mockData = [{ id: '1' }];
+    order.mockResolvedValue({ data: mockData, error: null });
+    const result = await promptMetricsService.fetchMetrics();
+    expect(from).toHaveBeenCalledWith('prompt_metrics');
+    expect(select).toHaveBeenCalled();
+    expect(order).toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+  });
+});

--- a/src/services/metrics/promptMetricsService.ts
+++ b/src/services/metrics/promptMetricsService.ts
@@ -1,0 +1,35 @@
+import { supabase } from '../../lib/supabase';
+
+export interface PromptMetric {
+  id: string;
+  prompt_id: string;
+  timestamp: string;
+  modelo_ia: string;
+  tiempo_respuesta_ms: number;
+  estado: 'success' | 'error';
+  tokens_entrada: number;
+  tokens_salida: number;
+  usuario_id?: string | null;
+  metadatos?: Record<string, unknown> | null;
+}
+
+export const promptMetricsService = {
+  async logMetric(metric: Omit<PromptMetric, 'id' | 'timestamp'> & { timestamp?: string }) {
+    const { data, error } = await supabase
+      .from('prompt_metrics')
+      .insert({ ...metric, timestamp: metric.timestamp ?? new Date().toISOString() })
+      .select('*')
+      .single();
+    if (error) throw error;
+    return data as PromptMetric;
+  },
+
+  async fetchMetrics(options?: { prompt_id?: string; modelo_ia?: string }) {
+    let query = supabase.from('prompt_metrics').select('*');
+    if (options?.prompt_id) query = query.eq('prompt_id', options.prompt_id);
+    if (options?.modelo_ia) query = query.eq('modelo_ia', options.modelo_ia);
+    const { data, error } = await query.order('timestamp', { ascending: false });
+    if (error) throw error;
+    return data as PromptMetric[];
+  },
+};

--- a/supabase/functions/_shared/metrics.ts
+++ b/supabase/functions/_shared/metrics.ts
@@ -1,0 +1,26 @@
+import { createClient } from 'npm:@supabase/supabase-js@2.39.7';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+
+export const supabaseAdmin = createClient(supabaseUrl, serviceKey, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+export interface PromptMetric {
+  prompt_id?: string;
+  modelo_ia: string;
+  tiempo_respuesta_ms: number;
+  estado: 'success' | 'error';
+  tokens_entrada?: number;
+  tokens_salida?: number;
+  usuario_id?: string | null;
+  metadatos?: Record<string, unknown> | null;
+}
+
+export async function logPromptMetric(metric: PromptMetric) {
+  const { error } = await supabaseAdmin.from('prompt_metrics').insert(metric);
+  if (error) {
+    console.error('[metrics] failed to insert metric:', error.message);
+  }
+}

--- a/supabase/functions/generate-illustration/index.ts
+++ b/supabase/functions/generate-illustration/index.ts
@@ -1,5 +1,6 @@
 import OpenAI from "npm:openai@4.28.0";
 import { GenerateIllustrationParams } from "./types.ts";
+import { logPromptMetric } from '../_shared/metrics.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -60,6 +61,7 @@ Deno.serve(async (req) => {
 
     const openai = new OpenAI({ apiKey: Deno.env.get("OPENAI_API_KEY")! });
 
+    const start = Date.now();
     const response = await openai.images.generate({
       model: "gpt-image-1",
       prompt,
@@ -67,6 +69,12 @@ Deno.serve(async (req) => {
       n: 1,
       referenced_image_ids: referencedImageIds,
       response_format: "url",
+    });
+    const elapsed = Date.now() - start;
+    await logPromptMetric({
+      modelo_ia: "gpt-image-1",
+      tiempo_respuesta_ms: elapsed,
+      estado: response.data?.[0]?.url ? 'success' : 'error',
     });
 
     if (!response.data || !response.data[0] || !response.data[0].url) {
@@ -80,9 +88,15 @@ Deno.serve(async (req) => {
 
   } catch (error) {
     console.error('Error generating illustration:', error);
+    await logPromptMetric({
+      modelo_ia: 'gpt-image-1',
+      tiempo_respuesta_ms: 0,
+      estado: 'error',
+      metadatos: { error: (error as Error).message },
+    });
     return new Response(
       JSON.stringify({ error: error.message }),
-      { 
+      {
         status: 500,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       }

--- a/supabase/functions/generate-spreads/index.ts
+++ b/supabase/functions/generate-spreads/index.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'npm:openai@4.28.0';
+import { logPromptMetric } from '../_shared/metrics.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -19,12 +20,19 @@ Deno.serve(async (req) => {
 
     const images = await Promise.all(
       prompts.map(async (prompt: string) => {
+        const start = Date.now();
         const response = await openai.images.generate({
           model: "dall-e-3",
           prompt,
           size: "2362x4724",
           quality: "hd",
           n: 1,
+        });
+        const elapsed = Date.now() - start;
+        await logPromptMetric({
+          modelo_ia: 'dall-e-3',
+          tiempo_respuesta_ms: elapsed,
+          estado: response.data?.[0]?.url ? 'success' : 'error',
         });
         return response.data[0].url;
       })
@@ -35,6 +43,12 @@ Deno.serve(async (req) => {
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (error) {
+    await logPromptMetric({
+      modelo_ia: 'dall-e-3',
+      tiempo_respuesta_ms: 0,
+      estado: 'error',
+      metadatos: { error: (error as Error).message },
+    });
     return new Response(
       JSON.stringify({ error: error.message }),
       { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }

--- a/supabase/migrations/20250528130000_create_prompt_metrics_table.sql
+++ b/supabase/migrations/20250528130000_create_prompt_metrics_table.sql
@@ -1,0 +1,55 @@
+/*
+  # Create prompt_metrics table to store prompt usage metrics
+  1. New table
+    - prompt_metrics
+      - id uuid primary key
+      - prompt_id uuid references prompts(id)
+      - timestamp timestamptz
+      - modelo_ia text
+      - tiempo_respuesta_ms integer
+      - estado text
+      - tokens_entrada integer
+      - tokens_salida integer
+      - usuario_id uuid references auth.users(id)
+      - metadatos jsonb
+  2. Indexes
+    - index on prompt_id
+    - index on timestamp
+  3. Row Level Security
+    - enabled
+    - admin users can read and insert
+*/
+
+create table if not exists prompt_metrics (
+  id uuid primary key default gen_random_uuid(),
+  prompt_id uuid references prompts(id),
+  timestamp timestamptz default now(),
+  modelo_ia text not null,
+  tiempo_respuesta_ms integer,
+  estado text,
+  tokens_entrada integer,
+  tokens_salida integer,
+  usuario_id uuid references auth.users(id),
+  metadatos jsonb
+);
+
+create index if not exists idx_prompt_metrics_prompt on prompt_metrics(prompt_id);
+create index if not exists idx_prompt_metrics_timestamp on prompt_metrics(timestamp);
+
+alter table prompt_metrics enable row level security;
+
+create policy "Admins read prompt metrics" on prompt_metrics
+for select to authenticated
+using (auth.jwt() ->> 'email' in (
+  'fabarca212@gmail.com',
+  'lucianoalonso2000@gmail.com',
+  'javier2000asr@gmail.com'
+));
+
+create policy "Admins insert prompt metrics" on prompt_metrics
+for insert to authenticated
+with check (auth.jwt() ->> 'email' in (
+  'fabarca212@gmail.com',
+  'lucianoalonso2000@gmail.com',
+  'javier2000asr@gmail.com'
+));


### PR DESCRIPTION
## Summary
- create `prompt_metrics` table migration with admin policies
- add PromptAnalytics admin page
- add prompt metrics service and tests
- link to analytics page from sidebar and routes
- log prompt metrics in all edge functions

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npx vitest run` *(fails: EHOSTUNREACH; no network access)*