### PR TITLE
Move character prompts to DB

### DIFF
--- a/supabase/functions/analyze-character/index.ts
+++ b/supabase/functions/analyze-character/index.ts
@@ -86,7 +86,6 @@ Deno.serve(async (req)=>{
     if (!imageUrl) {
       throw new Error('No image URL provided');
     }
-    let analysisPrompt = Deno.env.get('PROMPT_DESCRIPCION_PERSONAJE') || '';
     const { data: promptRow } = await supabaseAdmin
       .from('prompts')
       .select('id, content')
@@ -95,12 +94,10 @@ Deno.serve(async (req)=>{
     if (promptRow?.id) {
       promptId = promptRow.id;
     }
-    if (promptRow?.content) {
-      analysisPrompt = promptRow.content;
-    }
-    if (!analysisPrompt) {
+    if (!promptRow?.content) {
       throw new Error('Error de configuración: Falta el prompt de análisis de personaje');
     }
+    const analysisPrompt = promptRow.content;
     console.log(`[${FILE}] [INIT] Attempting to fetch image: ${imageUrl}`);
     const base64Image = await fetchImageAsBase64(imageUrl);
     const prompt = analysisPrompt.replace('{name}', name || '').replace('${sanitizedAge}', age?.toString() || '').replace('${sanitizedNotes}', sanitizedNotes || '');

--- a/supabase/functions/describe-and-sketch/index.ts
+++ b/supabase/functions/describe-and-sketch/index.ts
@@ -69,16 +69,15 @@ Deno.serve(async (req) => {
     // 1) Config y prompts
     const openaiKey = Deno.env.get('OPENAI_API_KEY');
     if (!openaiKey) throw new Error('Falta la clave de API de OpenAI');
-    let characterPrompt = Deno.env.get('PROMPT_CREAR_MINIATURA_PERSONAJE') || '';
     const { data: promptRow } = await supabaseAdmin
       .from('prompts')
       .select('content')
       .eq('type', 'PROMPT_CREAR_MINIATURA_PERSONAJE')
       .single();
-    if (promptRow?.content) {
-      characterPrompt = promptRow.content;
+    if (!promptRow?.content) {
+      throw new Error('Falta el prompt de generación de personaje');
     }
-    if (!characterPrompt) throw new Error('Falta el prompt de generación de personaje');
+    const characterPrompt = promptRow.content;
 
     // 2) Payload
     const rawPayload = await req.json().catch(() => {

--- a/supabase/migrations/20250601000000_migrate_prompt_secrets.sql
+++ b/supabase/migrations/20250601000000_migrate_prompt_secrets.sql
@@ -1,0 +1,14 @@
+/*
+  # Migrate prompt secrets to prompts table
+
+  Insert prompts that were previously stored as edge function secrets into
+  the 'prompts' table. Replace the placeholder values with the actual
+  prompt text before running the migration.
+*/
+
+insert into prompts(type, content)
+values
+  ('PROMPT_CREAR_MINIATURA_PERSONAJE', '<PROMPT_CREAR_MINIATURA_PERSONAJE>'),
+  ('PROMPT_DESCRIPCION_PERSONAJE', '<PROMPT_DESCRIPCION_PERSONAJE>')
+on conflict (type) do update set content = excluded.content;
+


### PR DESCRIPTION
## Summary
- remove env fallback for character prompts in edge functions
- insert placeholder prompts via new migration

## Testing
- `npm run lint` *(fails: many existing linter errors)*
- `npx tsc -p tsconfig.json`
