### PR TITLE
Implement advanced analytics dashboard

### DIFF
--- a/src/pages/Admin/Analytics/PromptAnalytics.tsx
+++ b/src/pages/Admin/Analytics/PromptAnalytics.tsx
@@ -4,6 +4,10 @@ import { analyticsService } from '../../../services/analyticsService';
 import {
   GeneralUsageMetrics,
   PromptPerformanceMetric,
+  TokenUsage,
+  ModelUsageMetric,
+  ErrorBreakdownMetric,
+  UserUsageMetric,
 } from '../../../types/analytics';
 
 const PromptAnalytics: React.FC = () => {
@@ -13,6 +17,10 @@ const PromptAnalytics: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [general, setGeneral] = useState<GeneralUsageMetrics | null>(null);
   const [prompts, setPrompts] = useState<PromptPerformanceMetric[]>([]);
+  const [tokens, setTokens] = useState<TokenUsage | null>(null);
+  const [models, setModels] = useState<ModelUsageMetric[]>([]);
+  const [errors, setErrors] = useState<ErrorBreakdownMetric[]>([]);
+  const [users, setUsers] = useState<UserUsageMetric[]>([]);
 
   const loadMetrics = async () => {
     if (!isAdmin) return;
@@ -22,12 +30,20 @@ const PromptAnalytics: React.FC = () => {
         from: from ? new Date(from) : undefined,
         to: to ? new Date(to) : undefined,
       };
-      const [g, p] = await Promise.all([
+      const [g, p, t, m, e, u] = await Promise.all([
         analyticsService.fetchGeneralUsage(range),
         analyticsService.fetchPromptPerformance(range),
+        analyticsService.fetchTokenUsage(range),
+        analyticsService.fetchModelUsage(range),
+        analyticsService.fetchErrorBreakdown(range),
+        analyticsService.fetchUserUsage(range),
       ]);
       setGeneral(g);
       setPrompts(p);
+      setTokens(t);
+      setModels(m);
+      setErrors(e);
+      setUsers(u);
     } catch (err) {
       console.error('Failed to load analytics', err);
     } finally {
@@ -89,6 +105,18 @@ const PromptAnalytics: React.FC = () => {
           </div>
         </div>
       )}
+      {tokens && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="p-4 bg-purple-50 rounded">
+            <p className="text-sm text-gray-500">Tokens de entrada</p>
+            <p className="text-xl font-semibold">{tokens.totalInputTokens}</p>
+          </div>
+          <div className="p-4 bg-purple-50 rounded">
+            <p className="text-sm text-gray-500">Tokens de salida</p>
+            <p className="text-xl font-semibold">{tokens.totalOutputTokens}</p>
+          </div>
+        </div>
+      )}
       {prompts.length > 0 && (
         <div className="space-y-2">
           <h2 className="text-xl font-semibold">Rendimiento de Prompts</h2>
@@ -113,6 +141,93 @@ const PromptAnalytics: React.FC = () => {
                       {((p.successCount / p.totalExecutions) * 100).toFixed(0)}%
                     </td>
                     <td className="p-2">{Math.round(p.averageResponseMs)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+      {models.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Uso por modelo</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Modelo</th>
+                  <th className="p-2">Ejecuciones</th>
+                  <th className="p-2">% Éxito</th>
+                  <th className="p-2">Prom. tokens in</th>
+                  <th className="p-2">Prom. tokens out</th>
+                  <th className="p-2">Prom. respuesta (ms)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {models.map((m) => (
+                  <tr key={m.model} className="border-t">
+                    <td className="p-2">{m.model}</td>
+                    <td className="p-2">{m.executions}</td>
+                    <td className="p-2">
+                      {((m.successCount / m.executions) * 100).toFixed(0)}%
+                    </td>
+                    <td className="p-2">{m.averageInputTokens.toFixed(1)}</td>
+                    <td className="p-2">{m.averageOutputTokens.toFixed(1)}</td>
+                    <td className="p-2">{Math.round(m.averageResponseMs)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+      {errors.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Clasificación de errores</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Tipo</th>
+                  <th className="p-2">Cantidad</th>
+                </tr>
+              </thead>
+              <tbody>
+                {errors.map((er) => (
+                  <tr key={er.status} className="border-t">
+                    <td className="p-2">{er.status}</td>
+                    <td className="p-2">{er.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+      {users.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Métricas por usuario</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Usuario</th>
+                  <th className="p-2">Ejecuciones</th>
+                  <th className="p-2">% Éxito</th>
+                  <th className="p-2">Tokens in</th>
+                  <th className="p-2">Tokens out</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => (
+                  <tr key={u.userId || 'unknown'} className="border-t">
+                    <td className="p-2">{u.userId ?? 'Desconocido'}</td>
+                    <td className="p-2">{u.executions}</td>
+                    <td className="p-2">
+                      {((u.successCount / u.executions) * 100).toFixed(0)}%
+                    </td>
+                    <td className="p-2">{u.totalInputTokens}</td>
+                    <td className="p-2">{u.totalOutputTokens}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -16,3 +16,30 @@ export interface PromptPerformanceMetric {
   successCount: number;
   averageResponseMs: number;
 }
+
+export interface TokenUsage {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+}
+
+export interface ModelUsageMetric {
+  model: string;
+  executions: number;
+  successCount: number;
+  averageResponseMs: number;
+  averageInputTokens: number;
+  averageOutputTokens: number;
+}
+
+export interface ErrorBreakdownMetric {
+  status: string;
+  count: number;
+}
+
+export interface UserUsageMetric {
+  userId: string | null;
+  executions: number;
+  successCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+}


### PR DESCRIPTION
## Summary
- extend `analyticsService` with functions for tokens, models, errors and user usage
- update types for new metrics
- enhance Admin analytics page with extra views

## Testing
- `npm run lint` *(fails: 57 errors)*
- `npm run test:e2e` *(fails: missing Xvfb)*