### PR TITLE
Implement advanced analytics dashboard

### DIFF
--- a/src/pages/Admin/Analytics/PromptAnalytics.tsx
+++ b/src/pages/Admin/Analytics/PromptAnalytics.tsx
@@ -4,6 +4,10 @@ import { analyticsService } from '../../../services/analyticsService';
 import {
   GeneralUsageMetrics,
   PromptPerformanceMetric,
+  TokenUsage,
+  ModelUsageMetric,
+  ErrorBreakdownMetric,
+  UserUsageMetric,
 } from '../../../types/analytics';
 
 const PromptAnalytics: React.FC = () => {
@@ -13,6 +17,10 @@ const PromptAnalytics: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [general, setGeneral] = useState<GeneralUsageMetrics | null>(null);
   const [prompts, setPrompts] = useState<PromptPerformanceMetric[]>([]);
+  const [tokens, setTokens] = useState<TokenUsage | null>(null);
+  const [models, setModels] = useState<ModelUsageMetric[]>([]);
+  const [errors, setErrors] = useState<ErrorBreakdownMetric[]>([]);
+  const [users, setUsers] = useState<UserUsageMetric[]>([]);
 
   const loadMetrics = async () => {
     if (!isAdmin) return;
@@ -22,12 +30,20 @@ const PromptAnalytics: React.FC = () => {
         from: from ? new Date(from) : undefined,
         to: to ? new Date(to) : undefined,
       };
-      const [g, p] = await Promise.all([
+      const [g, p, t, m, e, u] = await Promise.all([
         analyticsService.fetchGeneralUsage(range),
         analyticsService.fetchPromptPerformance(range),
+        analyticsService.fetchTokenUsage(range),
+        analyticsService.fetchModelUsage(range),
+        analyticsService.fetchErrorBreakdown(range),
+        analyticsService.fetchUserUsage(range),
       ]);
       setGeneral(g);
       setPrompts(p);
+      setTokens(t);
+      setModels(m);
+      setErrors(e);
+      setUsers(u);
     } catch (err) {
       console.error('Failed to load analytics', err);
     } finally {
@@ -89,6 +105,18 @@ const PromptAnalytics: React.FC = () => {
           </div>
         </div>
       )}
+      {tokens && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="p-4 bg-purple-50 rounded">
+            <p className="text-sm text-gray-500">Tokens de entrada</p>
+            <p className="text-xl font-semibold">{tokens.totalInputTokens}</p>
+          </div>
+          <div className="p-4 bg-purple-50 rounded">
+            <p className="text-sm text-gray-500">Tokens de salida</p>
+            <p className="text-xl font-semibold">{tokens.totalOutputTokens}</p>
+          </div>
+        </div>
+      )}
       {prompts.length > 0 && (
         <div className="space-y-2">
           <h2 className="text-xl font-semibold">Rendimiento de Prompts</h2>
@@ -113,6 +141,93 @@ const PromptAnalytics: React.FC = () => {
                       {((p.successCount / p.totalExecutions) * 100).toFixed(0)}%
                     </td>
                     <td className="p-2">{Math.round(p.averageResponseMs)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+      {models.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Uso por modelo</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Modelo</th>
+                  <th className="p-2">Ejecuciones</th>
+                  <th className="p-2">% Éxito</th>
+                  <th className="p-2">Prom. tokens in</th>
+                  <th className="p-2">Prom. tokens out</th>
+                  <th className="p-2">Prom. respuesta (ms)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {models.map((m) => (
+                  <tr key={m.model} className="border-t">
+                    <td className="p-2">{m.model}</td>
+                    <td className="p-2">{m.executions}</td>
+                    <td className="p-2">
+                      {((m.successCount / m.executions) * 100).toFixed(0)}%
+                    </td>
+                    <td className="p-2">{m.averageInputTokens.toFixed(1)}</td>
+                    <td className="p-2">{m.averageOutputTokens.toFixed(1)}</td>
+                    <td className="p-2">{Math.round(m.averageResponseMs)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+      {errors.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Clasificación de errores</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Tipo</th>
+                  <th className="p-2">Cantidad</th>
+                </tr>
+              </thead>
+              <tbody>
+                {errors.map((er) => (
+                  <tr key={er.status} className="border-t">
+                    <td className="p-2">{er.status}</td>
+                    <td className="p-2">{er.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+      {users.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Métricas por usuario</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Usuario</th>
+                  <th className="p-2">Ejecuciones</th>
+                  <th className="p-2">% Éxito</th>
+                  <th className="p-2">Tokens in</th>
+                  <th className="p-2">Tokens out</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => (
+                  <tr key={u.userId || 'unknown'} className="border-t">
+                    <td className="p-2">{u.userId ?? 'Desconocido'}</td>
+                    <td className="p-2">{u.executions}</td>
+                    <td className="p-2">
+                      {((u.successCount / u.executions) * 100).toFixed(0)}%
+                    </td>
+                    <td className="p-2">{u.totalInputTokens}</td>
+                    <td className="p-2">{u.totalOutputTokens}</td>
                   </tr>
                 ))}
               </tbody>

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -3,6 +3,10 @@ import {
   DateRange,
   GeneralUsageMetrics,
   PromptPerformanceMetric,
+  TokenUsage,
+  ModelUsageMetric,
+  ErrorBreakdownMetric,
+  UserUsageMetric,
 } from '../types/analytics';
 
 function applyDateFilter(query: any, column: string, range?: DateRange) {
@@ -67,6 +71,119 @@ export const analyticsService = {
       metric.averageResponseMs =
         (prevAvg * (metric.totalExecutions - 1) + (item.tiempo_respuesta_ms || 0)) /
         metric.totalExecutions;
+    });
+
+    return Object.values(grouped);
+  },
+
+  async fetchTokenUsage(range?: DateRange): Promise<TokenUsage> {
+    let query = supabase
+      .from('prompt_metrics')
+      .select('tokens_entrada,tokens_salida', { count: 'exact' });
+    query = applyDateFilter(query, 'timestamp', range);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    let totalInput = 0;
+    let totalOutput = 0;
+    (data || []).forEach((row: any) => {
+      totalInput += row.tokens_entrada || 0;
+      totalOutput += row.tokens_salida || 0;
+    });
+
+    return { totalInputTokens: totalInput, totalOutputTokens: totalOutput };
+  },
+
+  async fetchModelUsage(range?: DateRange): Promise<ModelUsageMetric[]> {
+    let query = supabase
+      .from('prompt_metrics')
+      .select(
+        'modelo_ia, estado, tiempo_respuesta_ms, tokens_entrada, tokens_salida'
+      );
+    query = applyDateFilter(query, 'timestamp', range);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const grouped: Record<string, ModelUsageMetric> = {};
+
+    (data || []).forEach((row: any) => {
+      const key = row.modelo_ia || 'unknown';
+      if (!grouped[key]) {
+        grouped[key] = {
+          model: key,
+          executions: 0,
+          successCount: 0,
+          averageResponseMs: 0,
+          averageInputTokens: 0,
+          averageOutputTokens: 0,
+        };
+      }
+      const metric = grouped[key];
+      metric.executions++;
+      if (row.estado === 'success') metric.successCount++;
+
+      metric.averageResponseMs =
+        (metric.averageResponseMs * (metric.executions - 1) + (row.tiempo_respuesta_ms || 0)) /
+        metric.executions;
+
+      metric.averageInputTokens =
+        (metric.averageInputTokens * (metric.executions - 1) + (row.tokens_entrada || 0)) /
+        metric.executions;
+
+      metric.averageOutputTokens =
+        (metric.averageOutputTokens * (metric.executions - 1) + (row.tokens_salida || 0)) /
+        metric.executions;
+    });
+
+    return Object.values(grouped);
+  },
+
+  async fetchErrorBreakdown(range?: DateRange): Promise<ErrorBreakdownMetric[]> {
+    let query = supabase.from('prompt_metrics').select('estado, error_type');
+    query = applyDateFilter(query, 'timestamp', range);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const counts: Record<string, number> = {};
+
+    (data || []).forEach((row: any) => {
+      const key = row.error_type || row.estado || 'unknown';
+      counts[key] = (counts[key] || 0) + 1;
+    });
+
+    return Object.entries(counts).map(([status, count]) => ({ status, count }));
+  },
+
+  async fetchUserUsage(range?: DateRange): Promise<UserUsageMetric[]> {
+    let query = supabase
+      .from('prompt_metrics')
+      .select('usuario_id, estado, tokens_entrada, tokens_salida');
+    query = applyDateFilter(query, 'timestamp', range);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const grouped: Record<string, UserUsageMetric> = {};
+
+    (data || []).forEach((row: any) => {
+      const key = row.usuario_id || 'unknown';
+      if (!grouped[key]) {
+        grouped[key] = {
+          userId: row.usuario_id,
+          executions: 0,
+          successCount: 0,
+          totalInputTokens: 0,
+          totalOutputTokens: 0,
+        };
+      }
+      const metric = grouped[key];
+      metric.executions++;
+      if (row.estado === 'success') metric.successCount++;
+      metric.totalInputTokens += row.tokens_entrada || 0;
+      metric.totalOutputTokens += row.tokens_salida || 0;
     });
 
     return Object.values(grouped);

--- a/src/services/metrics/promptMetricsService.ts
+++ b/src/services/metrics/promptMetricsService.ts
@@ -7,6 +7,7 @@ export interface PromptMetric {
   modelo_ia: string;
   tiempo_respuesta_ms: number;
   estado: 'success' | 'error';
+  error_type?: string | null;
   tokens_entrada: number;
   tokens_salida: number;
   usuario_id?: string | null;

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -16,3 +16,31 @@ export interface PromptPerformanceMetric {
   successCount: number;
   averageResponseMs: number;
 }
+
+export interface TokenUsage {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+}
+
+export interface ModelUsageMetric {
+  model: string;
+  executions: number;
+  successCount: number;
+  averageResponseMs: number;
+  averageInputTokens: number;
+  averageOutputTokens: number;
+}
+
+export interface ErrorBreakdownMetric {
+  status: string;
+  errorType?: string | null;
+  count: number;
+}
+
+export interface UserUsageMetric {
+  userId: string | null;
+  executions: number;
+  successCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -137,6 +137,7 @@ export type Database = {
           timestamp: string | null
           tokens_entrada: number | null
           tokens_salida: number | null
+          error_type: string | null
           usuario_id: string | null
         }
         Insert: {
@@ -149,6 +150,7 @@ export type Database = {
           timestamp?: string | null
           tokens_entrada?: number | null
           tokens_salida?: number | null
+          error_type?: string | null
           usuario_id?: string | null
         }
         Update: {
@@ -161,6 +163,7 @@ export type Database = {
           timestamp?: string | null
           tokens_entrada?: number | null
           tokens_salida?: number | null
+          error_type?: string | null
           usuario_id?: string | null
         }
         Relationships: [

--- a/supabase/functions/_shared/metrics.ts
+++ b/supabase/functions/_shared/metrics.ts
@@ -12,6 +12,7 @@ export interface PromptMetric {
   modelo_ia: string;
   tiempo_respuesta_ms: number;
   estado: 'success' | 'error';
+  error_type?: string | null;
   tokens_entrada?: number;
   tokens_salida?: number;
   usuario_id?: string | null;

--- a/supabase/functions/describe-and-sketch/index.ts
+++ b/supabase/functions/describe-and-sketch/index.ts
@@ -151,6 +151,7 @@ Deno.serve(async (req) => {
       modelo_ia: 'gpt-image-1',
       tiempo_respuesta_ms: elapsed,
       estado: editRes.ok ? 'success' : 'error',
+      error_type: editRes.ok ? null : 'service_error',
     });
     if (!editRes.ok) {
       const msg = editData.error?.message || editRes.statusText;
@@ -175,6 +176,7 @@ Deno.serve(async (req) => {
       modelo_ia: 'gpt-image-1',
       tiempo_respuesta_ms: 0,
       estado: 'error',
+      error_type: 'service_error',
       metadatos: { error: (error as Error).message },
     });
     return new Response(JSON.stringify({

--- a/supabase/functions/generate-illustration/index.ts
+++ b/supabase/functions/generate-illustration/index.ts
@@ -75,6 +75,7 @@ Deno.serve(async (req) => {
       modelo_ia: "gpt-image-1",
       tiempo_respuesta_ms: elapsed,
       estado: response.data?.[0]?.url ? 'success' : 'error',
+      error_type: response.data?.[0]?.url ? null : 'service_error',
     });
 
     if (!response.data || !response.data[0] || !response.data[0].url) {
@@ -92,6 +93,7 @@ Deno.serve(async (req) => {
       modelo_ia: 'gpt-image-1',
       tiempo_respuesta_ms: 0,
       estado: 'error',
+      error_type: 'service_error',
       metadatos: { error: (error as Error).message },
     });
     return new Response(

--- a/supabase/functions/generate-scene/index.ts
+++ b/supabase/functions/generate-scene/index.ts
@@ -71,6 +71,7 @@ Ilustración para libro infantil. Formato panorámico si es spread.`;
       modelo_ia: 'gpt-image-1',
       tiempo_respuesta_ms: elapsed,
       estado: response.data?.[0]?.url ? 'success' : 'error',
+      error_type: response.data?.[0]?.url ? null : 'service_error',
     });
 
     return new Response(
@@ -83,6 +84,7 @@ Ilustración para libro infantil. Formato panorámico si es spread.`;
       modelo_ia: 'gpt-image-1',
       tiempo_respuesta_ms: 0,
       estado: 'error',
+      error_type: 'service_error',
       metadatos: { error: (error as Error).message },
     });
     return new Response(

--- a/supabase/functions/generate-spreads/index.ts
+++ b/supabase/functions/generate-spreads/index.ts
@@ -33,6 +33,7 @@ Deno.serve(async (req) => {
           modelo_ia: 'dall-e-3',
           tiempo_respuesta_ms: elapsed,
           estado: response.data?.[0]?.url ? 'success' : 'error',
+          error_type: response.data?.[0]?.url ? null : 'service_error',
         });
         return response.data[0].url;
       })
@@ -47,6 +48,7 @@ Deno.serve(async (req) => {
       modelo_ia: 'dall-e-3',
       tiempo_respuesta_ms: 0,
       estado: 'error',
+      error_type: 'service_error',
       metadatos: { error: (error as Error).message },
     });
     return new Response(

--- a/supabase/functions/generate-variations/index.ts
+++ b/supabase/functions/generate-variations/index.ts
@@ -33,6 +33,7 @@ Deno.serve(async (req) => {
       modelo_ia: 'dall-e-2',
       tiempo_respuesta_ms: elapsed,
       estado: imageResponse.data?.[0]?.url ? 'success' : 'error',
+      error_type: imageResponse.data?.[0]?.url ? null : 'service_error',
     });
 
     return new Response(
@@ -47,6 +48,7 @@ Deno.serve(async (req) => {
       modelo_ia: 'dall-e-2',
       tiempo_respuesta_ms: 0,
       estado: 'error',
+      error_type: 'service_error',
       metadatos: { error: (error as Error).message },
     });
     return new Response(

--- a/supabase/migrations/20250529043300_add_error_type_to_prompt_metrics.sql
+++ b/supabase/migrations/20250529043300_add_error_type_to_prompt_metrics.sql
@@ -1,0 +1,2 @@
+-- Add column for error classification on prompt metrics
+alter table prompt_metrics add column if not exists error_type text;

--- a/supabase/supabase/.gitignore
+++ b/supabase/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/supabase/config.toml
+++ b/supabase/supabase/config.toml
@@ -1,0 +1,308 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "supabase"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 15
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+[edge_runtime]
+enabled = true
+# Configure one of the supported request policies: `oneshot`, `per_worker`.
+# Use `oneshot` for hot reload, or `per_worker` for load testing.
+policy = "oneshot"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 1
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"


### PR DESCRIPTION
## Summary
- extend `analyticsService` with error type aggregation
- allow logging error classification and token usage
- create migration adding `error_type` to `prompt_metrics`
- record error types in Supabase edge functions

## Testing
- `npm run lint` *(fails: 57 errors)*
- `npm run test:e2e` *(fails: missing Xvfb)*
