### PR TITLE
Update prompt metrics handling

### DIFF
--- a/src/pages/Admin/Analytics/PromptAnalytics.tsx
+++ b/src/pages/Admin/Analytics/PromptAnalytics.tsx
@@ -221,7 +221,7 @@ const PromptAnalytics: React.FC = () => {
               <tbody>
                 {users.map((u) => (
                   <tr key={u.userId || 'unknown'} className="border-t">
-                    <td className="p-2">{u.userId ?? 'Desconocido'}</td>
+                    <td className="p-2">{u.userEmail || u.userId || 'Desconocido'}</td>
                     <td className="p-2">{u.executions}</td>
                     <td className="p-2">
                       {((u.successCount / u.executions) * 100).toFixed(0)}%

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -162,7 +162,7 @@ export const analyticsService = {
   async fetchUserUsage(range?: DateRange): Promise<UserUsageMetric[]> {
     let query = supabase
       .from('prompt_metrics')
-      .select('usuario_id, estado, tokens_entrada, tokens_salida');
+      .select('usuario_id, estado, tokens_entrada, tokens_salida, user:usuario_id(email)');
     query = applyDateFilter(query, 'timestamp', range);
 
     const { data, error } = await query;
@@ -175,6 +175,7 @@ export const analyticsService = {
       if (!grouped[key]) {
         grouped[key] = {
           userId: row.usuario_id,
+          userEmail: row.user?.email ?? null,
           executions: 0,
           successCount: 0,
           totalInputTokens: 0,

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -41,6 +41,7 @@ export interface ErrorBreakdownMetric {
 
 export interface UserUsageMetric {
   userId: string | null;
+  userEmail?: string | null;
   executions: number;
   successCount: number;
   totalInputTokens: number;

--- a/supabase/functions/_shared/metrics.ts
+++ b/supabase/functions/_shared/metrics.ts
@@ -19,6 +19,25 @@ export interface PromptMetric {
   metadatos?: Record<string, unknown> | null;
 }
 
+export async function getUserId(req: Request): Promise<string | null> {
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+  const token = authHeader.replace(/^Bearer\s+/i, '');
+  try {
+    const { data, error } = await supabaseAdmin.auth.getUser(token);
+    if (error) {
+      console.error('[metrics] failed to get user:', error.message);
+      return null;
+    }
+    return data.user?.id ?? null;
+  } catch (err) {
+    console.error('[metrics] error getting user id:', err);
+    return null;
+  }
+}
+
 export async function logPromptMetric(metric: PromptMetric) {
   const { error } = await supabaseAdmin.from('prompt_metrics').insert(metric);
   if (error) {


### PR DESCRIPTION
## Summary
- remove env vars from prompts functions and read from `prompts` table
- log prompt id, user id, and token counts for character image generation
- capture user id in analyze-character metrics
- show user email on analytics per-user view

## Testing
- `npm run lint` *(fails: 57 errors)*