### PR TITLE
Improve prompt management UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import CharactersGrid from './components/Character/CharactersGrid';
 import NotificationBell from './components/Notifications/NotificationBell';
 import ToastContainer from './components/UI/ToastContainer';
 import ProfileSettings from './pages/ProfileSettings';
-import PromptManager from './pages/Admin/PromptManager';
+import PromptsManager from './pages/Admin/Prompts/PromptsManager';
 import PromptAnalytics from './pages/Admin/Analytics/PromptAnalytics';
 import { useProfileStore } from './stores/profileStore';
 
@@ -95,7 +95,7 @@ function AppContent() {
                 path="/admin/prompts"
                 element={
                   <PrivateRoute>
-                    <PromptManager />
+                    <PromptsManager />
                   </PrivateRoute>
                 }
               />

--- a/src/components/Prompts/PromptAccordion.tsx
+++ b/src/components/Prompts/PromptAccordion.tsx
@@ -1,0 +1,87 @@
+import React, { useState, useEffect } from 'react';
+import { ChevronDown } from 'lucide-react';
+import Button from '../UI/Button';
+import { Prompt } from '../../types/prompts';
+
+interface PromptAccordionProps {
+  prompt: Prompt;
+  onSave: (content: string) => Promise<void> | void;
+}
+
+const rtf = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
+
+const formatRelativeTime = (dateStr: string) => {
+  const diff = new Date(dateStr).getTime() - Date.now();
+  const sec = diff / 1000;
+  const abs = Math.abs(sec);
+  if (abs < 60) return rtf.format(Math.round(sec), 'second');
+  if (abs < 3600) return rtf.format(Math.round(sec / 60), 'minute');
+  if (abs < 86400) return rtf.format(Math.round(sec / 3600), 'hour');
+  if (abs < 2592000) return rtf.format(Math.round(sec / 86400), 'day');
+  if (abs < 31536000) return rtf.format(Math.round(sec / 2592000), 'month');
+  return rtf.format(Math.round(sec / 31536000), 'year');
+};
+
+const PromptAccordion: React.FC<PromptAccordionProps> = ({ prompt, onSave }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [content, setContent] = useState(prompt.content);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setContent(prompt.content);
+  }, [prompt.content]);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    await onSave(content);
+    setIsSaving(false);
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="border rounded">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100"
+      >
+        <span className="font-medium text-left">
+          {prompt.type} (v{prompt.version}, modificado {formatRelativeTime(prompt.updated_at)})
+        </span>
+        <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      </button>
+      {isOpen && (
+        <div className="p-4 space-y-4">
+          {isEditing ? (
+            <textarea
+              value={content}
+              onChange={e => setContent(e.target.value)}
+              rows={6}
+              className="w-full border rounded px-2 py-1 text-sm"
+            />
+          ) : (
+            <pre className="whitespace-pre-wrap text-sm">{prompt.content}</pre>
+          )}
+          <div className="flex justify-end gap-2">
+            {isEditing ? (
+              <>
+                <Button variant="secondary" onClick={() => { setIsEditing(false); setContent(prompt.content); }} disabled={isSaving}>
+                  Cancelar
+                </Button>
+                <Button onClick={handleSave} isLoading={isSaving}>
+                  Guardar
+                </Button>
+              </>
+            ) : (
+              <Button variant="ghost" onClick={() => setIsEditing(true)}>
+                Editar
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PromptAccordion;

--- a/src/components/Prompts/PromptForm.tsx
+++ b/src/components/Prompts/PromptForm.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { X } from 'lucide-react';
+import Button from '../UI/Button';
+
+interface PromptFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (type: string, content: string) => Promise<void> | void;
+}
+
+const PromptForm: React.FC<PromptFormProps> = ({ isOpen, onClose, onSave }) => {
+  const [type, setType] = useState('');
+  const [content, setContent] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [errors, setErrors] = useState<{ type?: string; content?: string }>({});
+
+  const handleSave = async () => {
+    const errs: { type?: string; content?: string } = {};
+    if (!type) errs.type = 'Requerido';
+    if (!content) errs.content = 'Requerido';
+    setErrors(errs);
+    if (Object.keys(errs).length > 0) return;
+
+    setIsSaving(true);
+    await onSave(type, content);
+    setIsSaving(false);
+    setType('');
+    setContent('');
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg overflow-hidden">
+        <div className="p-4 border-b border-gray-200 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Nuevo Prompt</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="p-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Tipo</label>
+            <input
+              value={type}
+              onChange={e => setType(e.target.value)}
+              className="mt-1 w-full border rounded px-2 py-1 text-sm"
+            />
+            {errors.type && <p className="text-xs text-red-500">{errors.type}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Contenido</label>
+            <textarea
+              value={content}
+              onChange={e => setContent(e.target.value)}
+              rows={6}
+              className="mt-1 w-full border rounded px-2 py-1 text-sm"
+            />
+            {errors.content && <p className="text-xs text-red-500">{errors.content}</p>}
+          </div>
+        </div>
+        <div className="p-4 border-t border-gray-200 flex justify-end gap-2">
+          <Button variant="secondary" onClick={onClose} disabled={isSaving}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSave} isLoading={isSaving}>
+            Guardar
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PromptForm;

--- a/src/hooks/usePrompts.ts
+++ b/src/hooks/usePrompts.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from 'react';
+import { promptService } from '../services/promptService';
+import { Prompt } from '../types/prompts';
+import { useAdmin } from '../context/AdminContext';
+
+export const usePrompts = () => {
+  const isAdmin = useAdmin();
+  const [prompts, setPrompts] = useState<Prompt[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPrompts = useCallback(async () => {
+    if (!isAdmin) return;
+    setLoading(true);
+    try {
+      const data = await promptService.fetchPrompts();
+      setPrompts(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [isAdmin]);
+
+  const createPrompt = useCallback(
+    async (type: string, content: string) => {
+      if (!isAdmin) return null;
+      setSaving(true);
+      try {
+        const created = await promptService.upsertPrompt(type, content);
+        setPrompts(prev => [...prev, created]);
+        return created;
+      } catch (err) {
+        setError((err as Error).message);
+        return null;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [isAdmin]
+  );
+
+  const updatePrompt = useCallback(
+    async (id: string, content: string) => {
+      if (!isAdmin) return null;
+      const current = prompts.find(p => p.id === id);
+      if (!current) return null;
+      setSaving(true);
+      try {
+        const updated = await promptService.upsertPrompt(current.type, content);
+        setPrompts(prev => prev.map(p => (p.id === id ? updated : p)));
+        return updated;
+      } catch (err) {
+        setError((err as Error).message);
+        return null;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [isAdmin, prompts]
+  );
+
+  useEffect(() => {
+    loadPrompts();
+  }, [loadPrompts]);
+
+  return { prompts, loading, saving, error, createPrompt, updatePrompt, loadPrompts };
+};

--- a/src/pages/Admin/Prompts/PromptsManager.tsx
+++ b/src/pages/Admin/Prompts/PromptsManager.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { usePrompts } from '../../../hooks/usePrompts';
+import PromptForm from '../../../components/Prompts/PromptForm';
+import PromptAccordion from '../../../components/Prompts/PromptAccordion';
+import Button from '../../../components/UI/Button';
+import { useAdmin } from '../../../context/AdminContext';
+
+const PromptsManager: React.FC = () => {
+  const isAdmin = useAdmin();
+  const { prompts, createPrompt, updatePrompt, loading } = usePrompts();
+  const [showForm, setShowForm] = useState(false);
+
+  if (!isAdmin) {
+    return <p>No autorizado</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Gestión de Prompts</h1>
+        <Button onClick={() => setShowForm(true)}>Nuevo Prompt</Button>
+      </div>
+      {loading && <p>Cargando...</p>}
+      <div className="space-y-2">
+        {prompts.map(p => (
+          <PromptAccordion key={p.id} prompt={p} onSave={content => updatePrompt(p.id, content)} />
+        ))}
+      </div>
+      <PromptForm
+        isOpen={showForm}
+        onClose={() => setShowForm(false)}
+        onSave={async (type, content) => {
+          await createPrompt(type, content);
+          setShowForm(false);
+        }}
+      />
+    </div>
+  );
+};
+
+export default PromptsManager;

--- a/src/types/prompts.ts
+++ b/src/types/prompts.ts
@@ -1,0 +1,17 @@
+export interface Prompt {
+  id: string;
+  type: string;
+  content: string;
+  version: number;
+  updated_at: string;
+  updated_by?: string | null;
+}
+
+export interface PromptVersion {
+  id: string;
+  prompt_id: string;
+  version: number;
+  content: string;
+  created_at: string;
+  created_by?: string | null;
+}


### PR DESCRIPTION
## Summary
- enhance admin prompt management UI with accordion and modal
- add new PromptForm and PromptAccordion components
- add hooks/usePrompts for loading and saving prompts
- expose new PromptsManager page and route
- define Prompt types

## Testing
- `npm run lint` *(fails: several existing lint errors in supabase functions)*