### PR TITLE
Fix prompt metrics logging

### DIFF
--- a/src/components/Character/CharacterForm.tsx
+++ b/src/components/Character/CharacterForm.tsx
@@ -74,10 +74,12 @@ const CharacterForm: React.FC<CharacterFormProps> = ({ onSave, onCancel, id: pro
 
   const callAnalyzeCharacter = async (attempt = 0): Promise<any> => {
     try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY;
       const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/analyze-character`, {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
@@ -234,10 +236,12 @@ const CharacterForm: React.FC<CharacterFormProps> = ({ onSave, onCancel, id: pro
         // Llamada a describe-and-sketch (para generar la miniatura)
         (async () => {
           try {
+            const { data: { session } } = await supabase.auth.getSession();
+            const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY;
             const thumbnailResponse = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/describe-and-sketch`, {
               method: 'POST',
               headers: {
-                'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+                'Authorization': `Bearer ${token}`,
                 'Content-Type': 'application/json'
               },
               body: JSON.stringify({

--- a/src/components/Wizard/steps/ExportStep.tsx
+++ b/src/components/Wizard/steps/ExportStep.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { useWizard } from '../../../context/WizardContext';
+import { useAuth } from '../../../context/AuthContext';
 import { Download, Copy, Check, Loader } from 'lucide-react';
 import Button from '../../UI/Button';
 
 const ExportStep: React.FC = () => {
   const { generatedPages } = useWizard();
+  const { supabase } = useAuth();
   const [saveToLibrary, setSaveToLibrary] = useState(true);
   const [isExporting, setIsExporting] = useState(false);
   const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
@@ -13,10 +15,12 @@ const ExportStep: React.FC = () => {
   const handleExport = async () => {
     setIsExporting(true);
     try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY;
       const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/story/export`, {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({

--- a/src/hooks/useCharacterGeneration.ts
+++ b/src/hooks/useCharacterGeneration.ts
@@ -15,10 +15,12 @@ export const useCharacterGeneration = (character: Character) => {
 
     for (const style of visualStyles) {
       try {
+        const { data: { session } } = await supabase.auth.getSession();
+        const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY;
         const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-illustration`, {
           method: 'POST',
           headers: {
-            'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+            'Authorization': `Bearer ${token}`,
             'Content-Type': 'application/json'
           },
           body: JSON.stringify({
@@ -58,10 +60,12 @@ export const useCharacterGeneration = (character: Character) => {
     if (!frontalViewUrl || !traseraViewUrl) return;
 
     try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY;
       const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-illustration`, {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -162,7 +162,9 @@ export const analyticsService = {
   async fetchUserUsage(range?: DateRange): Promise<UserUsageMetric[]> {
     let query = supabase
       .from('prompt_metrics')
-      .select('usuario_id, estado, tokens_entrada, tokens_salida, user:usuario_id(email)');
+      .select(
+        'usuario_id, estado, tokens_entrada, tokens_salida, user:auth.users!prompt_metrics_usuario_id_fkey(email)'
+      );
     query = applyDateFilter(query, 'timestamp', range);
 
     const { data, error } = await query;

--- a/supabase/functions/describe-and-sketch/index.ts
+++ b/supabase/functions/describe-and-sketch/index.ts
@@ -150,14 +150,16 @@ Deno.serve(async (req) => {
     });
     const elapsed = Date.now() - start;
     const editData = await editRes.json();
+    const tokensEntrada = editData.usage?.input_tokens ?? 0;
+    const tokensSalida = editData.usage?.output_tokens ?? 0;
     await logPromptMetric({
       prompt_id: promptId,
       modelo_ia: 'gpt-image-1',
       tiempo_respuesta_ms: elapsed,
       estado: editRes.ok ? 'success' : 'error',
       error_type: editRes.ok ? null : 'service_error',
-      tokens_entrada: 0,
-      tokens_salida: 0,
+      tokens_entrada: tokensEntrada,
+      tokens_salida: tokensSalida,
       usuario_id: userId,
     });
     if (!editRes.ok) {


### PR DESCRIPTION
## Summary
- send user's session token to Supabase edge functions
- record tokens for gpt-image-1 responses
- fix analytics query joining with auth.users

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Xvfb missing)*