### PR TITLE
Display token averages in analytics

### DIFF
--- a/src/lib/formatNumber.ts
+++ b/src/lib/formatNumber.ts
@@ -1,0 +1,3 @@
+export function formatNumber(num: number): string {
+  return Math.round(num).toLocaleString('es-ES');
+}

--- a/src/pages/Admin/Analytics/PromptAnalytics.tsx
+++ b/src/pages/Admin/Analytics/PromptAnalytics.tsx
@@ -9,6 +9,7 @@ import {
   ErrorBreakdownMetric,
   UserUsageMetric,
 } from '../../../types/analytics';
+import { formatNumber } from '../../../lib/formatNumber';
 
 const PromptAnalytics: React.FC = () => {
   const isAdmin = useAdmin();
@@ -109,11 +110,15 @@ const PromptAnalytics: React.FC = () => {
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="p-4 bg-purple-50 rounded">
             <p className="text-sm text-gray-500">Tokens de entrada</p>
-            <p className="text-xl font-semibold">{tokens.totalInputTokens}</p>
+            <p className="text-xl font-semibold">
+              {formatNumber(tokens.totalInputTokens)} ({formatNumber(tokens.averageInputTokens)})
+            </p>
           </div>
           <div className="p-4 bg-purple-50 rounded">
             <p className="text-sm text-gray-500">Tokens de salida</p>
-            <p className="text-xl font-semibold">{tokens.totalOutputTokens}</p>
+            <p className="text-xl font-semibold">
+              {formatNumber(tokens.totalOutputTokens)} ({formatNumber(tokens.averageOutputTokens)})
+            </p>
           </div>
         </div>
       )}

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -82,7 +82,7 @@ export const analyticsService = {
       .select('tokens_entrada,tokens_salida', { count: 'exact' });
     query = applyDateFilter(query, 'timestamp', range);
 
-    const { data, error } = await query;
+    const { data, error, count } = await query;
     if (error) throw error;
 
     let totalInput = 0;
@@ -92,7 +92,14 @@ export const analyticsService = {
       totalOutput += row.tokens_salida || 0;
     });
 
-    return { totalInputTokens: totalInput, totalOutputTokens: totalOutput };
+    const executions = count || (data ? data.length : 0);
+
+    return {
+      totalInputTokens: totalInput,
+      totalOutputTokens: totalOutput,
+      averageInputTokens: executions ? totalInput / executions : 0,
+      averageOutputTokens: executions ? totalOutput / executions : 0,
+    };
   },
 
   async fetchModelUsage(range?: DateRange): Promise<ModelUsageMetric[]> {

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -20,6 +20,8 @@ export interface PromptPerformanceMetric {
 export interface TokenUsage {
   totalInputTokens: number;
   totalOutputTokens: number;
+  averageInputTokens: number;
+  averageOutputTokens: number;
 }
 
 export interface ModelUsageMetric {


### PR DESCRIPTION
## Summary
- add helper to format numbers using dot as thousands separator
- include average token metrics from backend
- display token usage as total and average per query

## Testing
- `npm run lint` *(fails: several existing lint errors)*