### PR TITLE
Implement async thumbnail variants

### DIFF
--- a/src/hooks/useCharacter.ts
+++ b/src/hooks/useCharacter.ts
@@ -1,0 +1,77 @@
+import { useAuth } from '../context/AuthContext';
+import { Character, ThumbnailStyle } from '../types/character';
+import { promptService } from '../services/promptService';
+import { characterService } from '../services/characterService';
+
+const STYLE_MAP: Array<{ key: ThumbnailStyle; type: string }> = [
+  { key: 'kawaii', type: 'PROMPT_ESTILO_KAWAII' },
+  { key: 'acuarela', type: 'PROMPT_ESTILO_ACUARELADIGITAL' },
+  { key: 'bordado', type: 'PROMPT_ESTILO_BORDADO' },
+  { key: 'mano', type: 'PROMPT_ESTILO_MANO' },
+  { key: 'recortes', type: 'PROMPT_ESTILO_RECORTES' },
+  { key: 'trasera', type: 'PROMPT_VARIANTE_TRASERA' },
+  { key: 'lateral', type: 'PROMPT_VARIANTE_LATERAL' },
+];
+
+export const useCharacter = () => {
+  const { supabase, user } = useAuth();
+
+  const generateAdditionalThumbnails = async (character: Character) => {
+    if (!user || !character.thumbnailUrl) return;
+    try {
+      const types = STYLE_MAP.map((s) => s.type);
+      const prompts = await promptService.getPromptsByTypes(types);
+
+      const tasks = STYLE_MAP.map(async (style) => {
+        const promptType = style.type;
+        const prompt = prompts[promptType];
+        if (!prompt) return;
+        try {
+          const { data: { session } } = await supabase.auth.getSession();
+          const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+          const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-thumbnail-variant`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              imageUrl: character.thumbnailUrl,
+              promptType
+            })
+          });
+
+          if (!response.ok) throw new Error('Failed to generate');
+          const data = await response.json();
+          const url = data.url || data.thumbnailUrl;
+          if (!url) throw new Error('No URL returned');
+
+          const res = await fetch(url);
+          const blob = await res.blob();
+          const path = `thumbnails/${user.id}/${character.id}_${style.key}.png`;
+          const { error: uploadError } = await supabase.storage
+            .from('storage')
+            .upload(path, blob, { contentType: 'image/png', upsert: true });
+          if (uploadError) throw uploadError;
+          const { data: { publicUrl } } = supabase.storage
+            .from('storage')
+            .getPublicUrl(path);
+          await characterService.upsertThumbnail({
+            character_id: character.id,
+            style_type: style.key,
+            url: publicUrl,
+          });
+        } catch (err) {
+          console.error(`Error generating ${style.key} thumbnail`, err);
+        }
+      });
+
+      await Promise.allSettled(tasks);
+    } catch (err) {
+      console.error('Error generating additional thumbnails', err);
+    }
+  };
+
+  return { generateAdditionalThumbnails };
+};

--- a/src/services/characterService.ts
+++ b/src/services/characterService.ts
@@ -1,0 +1,11 @@
+import { supabase } from '../lib/supabase';
+import { CharacterThumbnail } from '../types/character';
+
+export const characterService = {
+  async upsertThumbnail(thumbnail: CharacterThumbnail): Promise<void> {
+    const { error } = await supabase
+      .from('character_thumbnails')
+      .upsert(thumbnail, { onConflict: 'character_id,style_type' });
+    if (error) throw error;
+  },
+};

--- a/src/services/promptService.ts
+++ b/src/services/promptService.ts
@@ -28,6 +28,20 @@ export const promptService = {
     return data as Prompt | null;
   },
 
+  async getPromptsByTypes(types: string[]): Promise<Record<string, string>> {
+    if (types.length === 0) return {};
+    const { data, error } = await supabase
+      .from('prompts')
+      .select('type, content')
+      .in('type', types);
+    if (error) throw error;
+    const map: Record<string, string> = {};
+    for (const row of data as { type: string; content: string }[]) {
+      map[row.type] = row.content;
+    }
+    return map;
+  },
+
   async upsertPrompt(type: string, content: string): Promise<Prompt> {
     const { data, error } = await supabase
       .from('prompts')

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -41,3 +41,21 @@ export interface GenerateCharacterParams {
   output?: OutputFormat;
   referencedImageIds: string[];
 }
+
+export type ThumbnailStyle =
+  | 'kawaii'
+  | 'acuarela'
+  | 'bordado'
+  | 'mano'
+  | 'recortes'
+  | 'trasera'
+  | 'lateral';
+
+export interface CharacterThumbnail {
+  id?: string;
+  character_id: string;
+  style_type: ThumbnailStyle;
+  url: string;
+  created_at?: string;
+  updated_at?: string;
+}

--- a/supabase/functions/generate-thumbnail-variant/index.ts
+++ b/supabase/functions/generate-thumbnail-variant/index.ts
@@ -1,0 +1,122 @@
+import { createClient } from 'npm:@supabase/supabase-js@2.39.7';
+import { logPromptMetric, getUserId } from '../_shared/metrics.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type'
+};
+
+const supabaseAdmin = createClient(
+  Deno.env.get('SUPABASE_URL') ?? '',
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  { auth: { persistSession: false, autoRefreshToken: false } }
+);
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  let promptId: string | undefined;
+  let userId: string | null = null;
+
+  try {
+    const { imageUrl, promptType } = await req.json();
+    if (!imageUrl || !promptType) {
+      throw new Error('Missing imageUrl or promptType');
+    }
+
+    const { data: promptRow } = await supabaseAdmin
+      .from('prompts')
+      .select('id, content')
+      .eq('type', promptType)
+      .single();
+
+    const stylePrompt = promptRow?.content || '';
+    promptId = promptRow?.id;
+    if (!stylePrompt) {
+      throw new Error('Prompt not found');
+    }
+
+    userId = await getUserId(req);
+
+    const imgRes = await fetch(imageUrl);
+    if (!imgRes.ok) {
+      throw new Error(`Failed to download image: ${imgRes.status}`);
+    }
+    const buf = await imgRes.arrayBuffer();
+    const urlPath = new URL(imageUrl).pathname;
+    const ext = urlPath.split('.').pop()?.toLowerCase() || 'png';
+    const mimeMap: Record<string, string> = {
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      png: 'image/png',
+      webp: 'image/webp'
+    };
+    const mimeType = mimeMap[ext] || 'image/png';
+    const blob = new Blob([buf], { type: mimeType });
+
+    const formData = new FormData();
+    formData.append('model', 'gpt-image-1');
+    formData.append('prompt', stylePrompt);
+    formData.append('size', '1024x1024');
+    formData.append('n', '1');
+    formData.append('image', blob, `reference.${ext}`);
+
+    const start = Date.now();
+    const openaiKey = Deno.env.get('OPENAI_API_KEY');
+    const editRes = await fetch('https://api.openai.com/v1/images/edits', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${openaiKey}` },
+      body: formData
+    });
+    const elapsed = Date.now() - start;
+    const editData = await editRes.json();
+    const tokensIn = editData.usage?.input_tokens ?? 0;
+    const tokensOut = editData.usage?.output_tokens ?? 0;
+
+    await logPromptMetric({
+      prompt_id: promptId,
+      modelo_ia: 'gpt-image-1',
+      tiempo_respuesta_ms: elapsed,
+      estado: editRes.ok ? 'success' : 'error',
+      error_type: editRes.ok ? null : 'service_error',
+      tokens_entrada: tokensIn,
+      tokens_salida: tokensOut,
+      usuario_id: userId,
+    });
+
+    if (!editRes.ok) {
+      const msg = editData.error?.message || editRes.statusText;
+      throw new Error(msg);
+    }
+
+    const b64 = editData.data?.[0]?.b64_json;
+    if (!b64) {
+      throw new Error('No image returned');
+    }
+    const resultUrl = `data:${mimeType};base64,${b64}`;
+
+    return new Response(JSON.stringify({ thumbnailUrl: resultUrl }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    });
+
+  } catch (error) {
+    console.error('Error in generate-thumbnail-variant:', error);
+    await logPromptMetric({
+      prompt_id: promptId,
+      modelo_ia: 'gpt-image-1',
+      tiempo_respuesta_ms: 0,
+      estado: 'error',
+      error_type: 'service_error',
+      tokens_entrada: 0,
+      tokens_salida: 0,
+      usuario_id: userId,
+      metadatos: { error: (error as Error).message },
+    });
+    return new Response(JSON.stringify({ error: (error as Error).message }), {
+      status: 400,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    });
+  }
+});

--- a/supabase/migrations/20250530120000_create_character_thumbnails_table.sql
+++ b/supabase/migrations/20250530120000_create_character_thumbnails_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.character_thumbnails (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  character_id UUID NOT NULL REFERENCES public.characters(id) ON DELETE CASCADE,
+  style_type TEXT NOT NULL,
+  url TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(character_id, style_type)
+);


### PR DESCRIPTION
## Summary
- generate character thumbnails in parallel styles using new edge function
- store results in `character_thumbnails` table via service
- fetch prompt templates in batches
- add hook for character utilities
- start async variant generation after main thumbnail
- add migration for `character_thumbnails` table
- add `generate-thumbnail-variant` edge function

## Testing
- `npm run lint` *(fails: 66 problems)*