### PR TITLE
Update DesignStep to show character thumbnails

### DIFF
--- a/src/services/characterService.ts
+++ b/src/services/characterService.ts
@@ -8,4 +8,13 @@ export const characterService = {
       .upsert(thumbnail, { onConflict: 'character_id,style_type' });
     if (error) throw error;
   },
+
+  async getThumbnailsByCharacter(characterId: string): Promise<CharacterThumbnail[]> {
+    const { data, error } = await supabase
+      .from('character_thumbnails')
+      .select('*')
+      .eq('character_id', characterId);
+    if (error) throw error;
+    return (data as CharacterThumbnail[]) || [];
+  },
 };


### PR DESCRIPTION
## Summary
- fetch character thumbnails from Supabase
- display generated thumbnails on style selection cards
- show selected style preview
- expose `getThumbnailsByCharacter` in `characterService`

## Testing
- `npm run lint` *(fails: NotificationBell unused, etc.)*
- `npm run test:e2e` *(fails: missing Xvfb)*