### PR TITLE
Update Cypress login flow for landing page

### DIFF
--- a/README-cypress.md
+++ b/README-cypress.md
@@ -47,8 +47,9 @@ Las pruebas E2E están organizadas de la siguiente manera:
 
 ## Comandos personalizados
 
-Se han creado varios comandos personalizados para facilitar las pruebas:
+- Se han creado varios comandos personalizados para facilitar las pruebas:
 
+- `cy.navigateToLogin()`: Navega desde la landing page hasta el formulario de login.
 - `cy.login(email, password)`: Inicia sesión con las credenciales proporcionadas.
 - `cy.openNewStoryModal()`: Abre el asistente de creación de cuentos y muestra el modal de selección de personajes.
 - `cy.createNewCharacterFromModal()`: Abre el formulario para crear un personaje dentro de dicho modal.

--- a/cypress/e2e/flows/1_login.cy.js
+++ b/cypress/e2e/flows/1_login.cy.js
@@ -13,10 +13,10 @@ describe('1. Login Exitoso', function() {
   });
 
   it('Debe permitir iniciar sesión con credenciales válidas', function() {
-    // Visitar la página de login
-    cy.visit('/');
-    
-    // Verificar que estamos en la página de login
+    // Navegar desde la landing hasta el formulario de login
+    cy.navigateToLogin();
+
+    // Verificar que estamos en el formulario de login
     cy.contains('h2', 'La CuenterIA').should('be.visible');
     
     // Ingresar credenciales

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -2,14 +2,33 @@
 // Comandos personalizados para las pruebas de La CuenterIA
 // ***********************************************
 
+// -- Comando para navegar desde el landing hasta el formulario de login --
+Cypress.Commands.add('navigateToLogin', () => {
+  // Visitar la página inicial (landing)
+  cy.visit('/');
+
+  // Esperar a que el botón "Comenzar" esté visible tras la animación
+  cy.contains('a, button', 'Comenzar', { timeout: 10000 })
+    .should('be.visible')
+    .click();
+
+  // Verificar que se cargó la página de login
+  cy.url().should('include', '/login');
+  cy.get('input[id="email"]', { timeout: 10000 }).should('be.visible');
+});
+
 // -- Comando para iniciar sesión --
 Cypress.Commands.add('login', (email, password) => {
-  cy.visit('/');
+  // Navegar al formulario de login desde el landing
+  cy.navigateToLogin();
+
   cy.get('input[id="email"]').type(email);
   cy.get('input[id="password"]').type(password);
   cy.contains('button', 'Iniciar sesión').click();
+
   // Esperar a que se redirija a la página de inicio
   cy.url().should('include', '/home');
+
   // Verificar que se muestra el mensaje de bienvenida (header con el logo)
   cy.get('header').should('be.visible');
   cy.get('header').find('h1').should('contain', 'La CuenterIA');


### PR DESCRIPTION
## Summary
- update `cy.login` to navigate from landing page
- add new `cy.navigateToLogin` command
- adjust login test to use landing page
- document new command in cypress README

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*