### PR TITLE
Fix UI positioning and theme persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import ProfileSettings from './pages/ProfileSettings';
 import PromptsManager from './pages/Admin/Prompts/PromptsManager';
 import PromptAnalytics from './pages/Admin/Analytics/PromptAnalytics';
 import { useProfileStore } from './stores/profileStore';
+import { ThemeProvider, useTheme } from './context/ThemeContext';
 import { motion, AnimatePresence } from 'framer-motion';
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
@@ -58,9 +59,9 @@ function AnimatedRoutes() {
           animate={{ opacity: 1, x: 0 }}
           exit={{ opacity: 0, x: -100 }}
           transition={{ duration: 0.3, ease: 'easeInOut' }}
-          className="min-h-screen bg-gradient-to-b from-purple-50 to-blue-50 flex flex-col lg:flex-row"
+          className="min-h-screen bg-gradient-to-b from-purple-50 to-blue-50 dark:bg-gray-900 dark:text-white flex flex-col lg:flex-row"
         >
-          <div className="hidden lg:block lg:w-60 lg:flex-shrink-0 bg-white border-r border-gray-200">
+          <div className="hidden lg:block lg:w-60 lg:flex-shrink-0 bg-white border-r border-gray-200 dark:bg-gray-800 dark:border-gray-700">
             <Sidebar />
           </div>
 
@@ -136,7 +137,7 @@ function AnimatedRoutes() {
                 <Route path="*" element={<Navigate to="/home" replace />} />
               </Routes>
             </main>
-            <footer className="py-4 text-center text-purple-600 text-sm">
+            <footer className="py-4 text-center text-purple-600 dark:text-purple-400 text-sm">
               <p>Customware © {new Date().getFullYear()}</p>
             </footer>
           </div>
@@ -151,6 +152,19 @@ function AppContent() {
   // El contenido de la aplicación ahora está manejado por AnimatedRoutes
   return <AnimatedRoutes />;
 }
+
+const ThemeInitializer: React.FC = () => {
+  const { setTheme } = useTheme();
+
+  React.useEffect(() => {
+    const profileStore = useProfileStore.getState();
+    if (profileStore.profile?.theme_preference) {
+      setTheme(profileStore.profile.theme_preference);
+    }
+  }, [setTheme]);
+
+  return null;
+};
 
 // Registrar el service worker para las notificaciones
 const registerServiceWorker = () => {
@@ -172,23 +186,17 @@ function App() {
   React.useEffect(() => {
     registerServiceWorker();
   }, []);
-  
-  React.useEffect(() => {
-    const profileStore = useProfileStore.getState();
-    if (profileStore.profile?.theme_preference === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-  }, []);
 
   return (
     <Router>
-      <AuthProvider>
-        <AdminProvider>
-          <AppContent />
-        </AdminProvider>
-      </AuthProvider>
+      <ThemeProvider>
+        <ThemeInitializer />
+        <AuthProvider>
+          <AdminProvider>
+            <AppContent />
+          </AdminProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </Router>
   );
 }

--- a/src/components/Notifications/NotificationBell.tsx
+++ b/src/components/Notifications/NotificationBell.tsx
@@ -73,7 +73,7 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ className = '' }) =
       </button>
 
       {isOpen && (
-        <div className="fixed left-0 top-[calc(var(--header-height,4rem))] mt-0 w-80 sm:w-96 z-50 notification-panel-container" data-testid="notification-panel">
+        <div className="fixed right-0 top-[calc(var(--header-height,4rem))] mt-0 w-80 sm:w-96 z-50 notification-panel-container" data-testid="notification-panel">
           <NotificationCenter onClose={() => setIsOpen(false)} />
         </div>
       )}

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -173,10 +173,10 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({ onClose }) => {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-xl border border-gray-200 max-h-[80vh] flex flex-col max-w-[calc(100vw-2rem)]" data-testid="notification-center">
+    <div className="bg-white dark:bg-gray-800 dark:text-gray-200 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 max-h-[80vh] flex flex-col max-w-[calc(100vw-2rem)]" data-testid="notification-center">
       {/* Header */}
-      <div className="p-4 border-b border-gray-200 flex justify-between items-center">
-        <h2 className="text-lg font-semibold text-gray-800">Notificaciones</h2>
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100">Notificaciones</h2>
         <div className="flex space-x-2">
           <button
             onClick={() => setIsFilterOpen(!isFilterOpen)}
@@ -201,7 +201,7 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({ onClose }) => {
 
       {/* Filter panel */}
       {isFilterOpen && (
-        <div className="p-4 border-b border-gray-200 bg-gray-50">
+        <div className="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700">
           <div className="flex flex-col space-y-3">
             <div className="relative">
               <input
@@ -260,7 +260,7 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({ onClose }) => {
       </div>
 
       {/* Actions */}
-      <div className="p-3 border-b border-gray-200 flex justify-between items-center bg-gray-50">
+      <div className="p-3 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center bg-gray-50 dark:bg-gray-700">
         <div className="flex items-center">
           <input
             type="checkbox"
@@ -324,7 +324,7 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({ onClose }) => {
           <div>
             {groupedNotifications.map((group) => (
               <div key={group.date} className="mb-2">
-                <div className="px-4 py-2 bg-gray-50 text-xs font-medium text-gray-500">
+                <div className="px-4 py-2 bg-gray-50 dark:bg-gray-700 text-xs font-medium text-gray-500 dark:text-gray-300">
                   {group.date}
                 </div>
                 {group.notifications
@@ -335,8 +335,8 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({ onClose }) => {
                   .map((notification) => (
                     <div
                       key={notification.id}
-                      className={`p-4 border-b border-gray-100 hover:bg-gray-50 transition-colors duration-150 ${
-                        !notification.read ? 'bg-purple-50' : ''
+                      className={`p-4 border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-150 ${
+                        !notification.read ? 'bg-purple-50 dark:bg-purple-900' : ''
                       }`}
                     >
                       <div className="flex items-start">
@@ -404,10 +404,10 @@ const NotificationCenter: React.FC<NotificationCenterProps> = ({ onClose }) => {
       </div>
 
       {/* Footer */}
-      <div className="p-3 border-t border-gray-200 bg-gray-50 text-center">
+      <div className="p-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700 text-center">
         <a
           href="/configuracion/notificaciones"
-          className="text-sm text-purple-600 hover:text-purple-800"
+          className="text-sm text-purple-600 hover:text-purple-800 dark:text-purple-400"
           onClick={(e) => {
             e.preventDefault();
             // Navigate to notification settings

--- a/src/components/UI/Toast.tsx
+++ b/src/components/UI/Toast.tsx
@@ -45,36 +45,36 @@ const Toast: React.FC<ToastProps> = ({
   const getBgColor = () => {
     switch (type) {
       case 'success':
-        return 'bg-green-50 border-green-200';
+        return 'bg-green-50 border-green-200 dark:bg-green-900 dark:border-green-700';
       case 'error':
-        return 'bg-red-50 border-red-200';
+        return 'bg-red-50 border-red-200 dark:bg-red-900 dark:border-red-700';
       case 'info':
-        return 'bg-blue-50 border-blue-200';
+        return 'bg-blue-50 border-blue-200 dark:bg-blue-900 dark:border-blue-700';
       case 'notification':
-        return 'bg-purple-50 border-purple-200';
+        return 'bg-purple-50 border-purple-200 dark:bg-purple-900 dark:border-purple-700';
       default:
-        return 'bg-gray-50 border-gray-200';
+        return 'bg-gray-50 border-gray-200 dark:bg-gray-800 dark:border-gray-700';
     }
   };
 
   const getTextColor = () => {
     switch (type) {
       case 'success':
-        return 'text-green-800';
+        return 'text-green-800 dark:text-green-200';
       case 'error':
-        return 'text-red-800';
+        return 'text-red-800 dark:text-red-200';
       case 'info':
-        return 'text-blue-800';
+        return 'text-blue-800 dark:text-blue-200';
       case 'notification':
-        return 'text-purple-800';
+        return 'text-purple-800 dark:text-purple-200';
       default:
-        return 'text-gray-800';
+        return 'text-gray-800 dark:text-gray-200';
     }
   };
 
   return (
-    <div 
-      className={`fixed bottom-4 right-4 z-50 max-w-md p-4 rounded-lg shadow-lg border ${getBgColor()} transition-opacity duration-300 ${
+    <div
+      className={`relative max-w-md w-80 p-4 rounded-lg shadow-lg border ${getBgColor()} transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`}
     >

--- a/src/components/UI/ToastContainer.tsx
+++ b/src/components/UI/ToastContainer.tsx
@@ -61,7 +61,7 @@ const ToastContainer: React.FC = () => {
   };
 
   return (
-    <div className="toast-container">
+    <div className="toast-container fixed right-4 top-[calc(var(--header-height,4rem)+1rem)] z-50 flex flex-col gap-2">
       {toasts.map(toast => (
         <Toast
           key={toast.id}

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,45 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored === 'dark' || stored === 'light') {
+      setThemeState(stored);
+      document.documentElement.classList.toggle('dark', stored === 'dark');
+    }
+  }, []);
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
+    localStorage.setItem('theme', newTheme);
+    document.documentElement.classList.toggle('dark', newTheme === 'dark');
+  };
+
+  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+};
+
+export { ThemeProvider, useTheme };

--- a/src/index.css
+++ b/src/index.css
@@ -43,8 +43,14 @@
 @media (max-width: 640px) {
   .notification-panel-container {
     width: calc(100vw - 2rem) !important;
-    margin-left: 1rem;
+    margin-right: 1rem;
   }
+}
+
+.toast-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 /* Set a default header height for tests */

--- a/src/pages/MyStories.tsx
+++ b/src/pages/MyStories.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { useAuth } from '../context/AuthContext';
-import { Plus, BookOpen, Pencil } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useEffect } from "react";
+import { useAuth } from "../context/AuthContext";
+import { Plus, BookOpen, Pencil } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 interface Story {
   id: string;
   title: string;
   created_at: string;
-  status: 'draft' | 'completed';
+  status: "draft" | "completed";
   cover_url: string;
 }
 
@@ -23,22 +23,22 @@ const MyStories: React.FC = () => {
   const loadStories = async () => {
     try {
       const { data, error } = await supabase
-        .from('stories')
-        .select('*')
-        .order('created_at', { ascending: false });
+        .from("stories")
+        .select("*")
+        .order("created_at", { ascending: false });
 
       if (error) throw error;
       setStories(data || []);
     } catch (error) {
-      console.error('Error loading stories:', error);
+      console.error("Error loading stories:", error);
     }
   };
 
   const handleNewStory = async () => {
     try {
       const { data: story, error } = await supabase
-        .from('stories')
-        .insert({ user_id: user?.id, status: 'draft', title: 'Nuevo cuento' })
+        .from("stories")
+        .insert({ user_id: user?.id, status: "draft", title: "Nuevo cuento" })
         .select()
         .single();
 
@@ -46,7 +46,7 @@ const MyStories: React.FC = () => {
 
       navigate(`/wizard/${story.id}`);
     } catch (err) {
-      console.error('Error creating story:', err);
+      console.error("Error creating story:", err);
     }
   };
 
@@ -59,11 +59,13 @@ const MyStories: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-purple-50 to-blue-50 p-6">
+    <div className="min-h-screen bg-gradient-to-b from-purple-50 to-blue-50 px-4 py-6 sm:p-6">
       <div className="max-w-7xl mx-auto">
-        <h1 className="text-3xl font-bold text-purple-800 mb-8">Mis Cuentos</h1>
+        <h1 className="text-2xl font-bold text-purple-800 mb-6 sm:text-3xl">
+          Mis Cuentos
+        </h1>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 sm:gap-6">
           {stories.map((story) => (
             <div
               key={story.id}
@@ -71,15 +73,20 @@ const MyStories: React.FC = () => {
             >
               <div className="aspect-square">
                 <img
-                  src={story.cover_url || 'https://images.pexels.com/photos/1148399/pexels-photo-1148399.jpeg'}
+                  src={
+                    story.cover_url ||
+                    "https://images.pexels.com/photos/1148399/pexels-photo-1148399.jpeg"
+                  }
                   alt={story.title}
                   className="w-full h-full object-cover"
                 />
               </div>
               <div className="p-4">
                 <div className="flex items-start justify-between mb-2">
-                  <h3 className="text-lg font-semibold text-gray-800">{story.title}</h3>
-                  {story.status === 'draft' && (
+                  <h3 className="text-lg font-semibold text-gray-800">
+                    {story.title}
+                  </h3>
+                  {story.status === "draft" && (
                     <span className="px-2 py-1 text-xs font-medium bg-yellow-100 text-yellow-800 rounded-full">
                       Borrador
                     </span>
@@ -96,7 +103,7 @@ const MyStories: React.FC = () => {
                     <BookOpen className="w-4 h-4" />
                     <span>Leer</span>
                   </button>
-                  {story.status === 'draft' && (
+                  {story.status === "draft" && (
                     <button
                       onClick={() => handleContinueStory(story.id)}
                       className="flex-1 flex items-center justify-center gap-2 px-4 py-2 border border-purple-600 text-purple-600 rounded-lg hover:bg-purple-50 transition-colors"
@@ -113,13 +120,12 @@ const MyStories: React.FC = () => {
 
         <button
           onClick={handleNewStory}
-          className="fixed bottom-8 right-8 flex items-center gap-2 px-6 py-3 bg-purple-600 text-white rounded-full shadow-lg hover:bg-purple-700 transition-colors"
+          className="fixed bottom-4 right-4 sm:bottom-8 sm:right-8 flex items-center gap-2 px-5 py-3 bg-purple-600 text-white rounded-full shadow-lg hover:bg-purple-700 transition-colors"
         >
           <Plus className="w-5 h-5" />
           <span>Nuevo cuento</span>
         </button>
       </div>
-
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- position NotificationCenter on the right
- move ToastContainer to top-right and style toasts for dark mode
- persist theme preference with ThemeContext
- adjust layout backgrounds for dark mode
- tweak global styles for notification panel and toast container
- make MyStories layout mobile-first

## Testing
- `npm run lint` *(fails: various unused variables in supabase functions)*

------
https://chatgpt.com/codex/tasks/task_b_68391492c8e0832c85a9457ce41caa0a