### PR TITLE
Fix unintended story creation and cleanup

### DIFF
--- a/src/components/Wizard/Wizard.tsx
+++ b/src/components/Wizard/Wizard.tsx
@@ -38,6 +38,24 @@ const Wizard: React.FC = () => {
     };
   }, [storyId, supabase]);
 
+  useEffect(() => {
+    const handleBeforeUnload = async () => {
+      if (!storyId) return;
+      const { data } = await supabase
+        .from('story_characters')
+        .select('character_id')
+        .eq('story_id', storyId);
+      if (!data || data.length === 0) {
+        await supabase.rpc('delete_full_story', { story_id: storyId });
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [storyId, supabase]);
+
   const renderStep = () => {
     switch (currentStep) {
       case 'characters':

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -78,12 +78,11 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const [generatedPages, setGeneratedPages] = useState<GeneratedPage[]>([]);
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
 
-  useAutosave(state, storyId || '');
+  useAutosave(state, storyId || null);
 
   useEffect(() => {
     const loadDraft = async () => {
       if (!storyId || !user) {
-        navigate('/');
         return;
       }
 
@@ -116,7 +115,6 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         }
       } catch (error) {
         console.error('Error loading draft:', error);
-        navigate('/');
       }
     };
 

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -20,17 +20,15 @@ export const useAutosave = (state: WizardState, initialStoryId: string | null) =
   // Initialize storyId on mount
   useEffect(() => {
     if (!storyIdRef.current) {
-      // Try to recover from localStorage first
-      const savedId = localStorage.getItem('current_story_draft_id');
-      if (savedId && isValidUUID(savedId)) {
-        storyIdRef.current = savedId;
-      } else if (initialStoryId && isValidUUID(initialStoryId)) {
+      if (initialStoryId && isValidUUID(initialStoryId)) {
         storyIdRef.current = initialStoryId;
         localStorage.setItem('current_story_draft_id', initialStoryId);
       } else {
-        const newId = crypto.randomUUID();
-        storyIdRef.current = newId;
-        localStorage.setItem('current_story_draft_id', newId);
+        // Avoid creating a new story automatically when no ID is provided
+        const savedId = localStorage.getItem('current_story_draft_id');
+        if (savedId && isValidUUID(savedId)) {
+          storyIdRef.current = savedId;
+        }
       }
     }
   }, [initialStoryId]);


### PR DESCRIPTION
## Summary
- prevent random draft creation on non-wizard pages
- avoid redirecting when wizard isn't active
- remove local new-story creation logic from `useAutosave`
- clean up draft stories on browser unload

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683a762acaa4832a89996dc6fb4455cb