### PR TITLE
Add environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ Plataforma web interactiva para crear cuentos infantiles personalizados con ilus
 git clone [url-del-repositorio]
 ```
 
-2. Instala las dependencias:
+2. Ejecuta el script de preparación del entorno:
 ```bash
-npm install
+./setup.sh
 ```
+Este paso asegura que todas las dependencias queden instaladas antes de perder acceso a la red en entornos como Codex.
 
 3. Configura las variables de entorno:
 ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Instala dependencias de Node y la CLI de Supabase
+# Este script se ejecuta durante el setup del entorno (por ejemplo Codex)
+# para dejar todo instalado antes de perder acceso a la red.
+
+set -e
+
+# Colores
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Instalar dependencias del proyecto
+if [ -f package-lock.json ]; then
+  echo -e "${YELLOW}• Instalando dependencias (npm ci)...${NC}"
+  npm ci
+else
+  echo -e "${YELLOW}• Instalando dependencias (npm install)...${NC}"
+  npm install
+fi
+
+# Instalar la CLI de Supabase si no está disponible
+if ! command -v supabase >/dev/null 2>&1; then
+  echo -e "${YELLOW}• Instalando Supabase CLI...${NC}"
+  npm install -g supabase
+fi
+
+echo -e "${GREEN}✓ Entorno listo${NC}"


### PR DESCRIPTION
## Summary
- provide a `setup.sh` helper to install dependencies and Supabase CLI
- update install docs to use the script

## Testing
- `npm run lint` *(fails: 48 errors, 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_683a79ae80b0832aa0bbe27b238f12b6