### PR TITLE
Fix story status after generation

### DIFF
--- a/supabase/functions/generate-story/index.ts
+++ b/supabase/functions/generate-story/index.ts
@@ -126,7 +126,7 @@ Deno.serve(async (req) => {
     await supabaseAdmin.from('stories')
       .update({
         title,
-        status: 'completed',
+        status: 'draft',
       })
       .eq('id', story_id);
 


### PR DESCRIPTION
## Summary
- keep story in `draft` status after generation

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_b_683df4d38184832ab6c574b1d68ce17f