### PR TITLE
Ensure story images use character thumbnails

### DIFF
--- a/docs/tech/story-generation.md
+++ b/docs/tech/story-generation.md
@@ -12,13 +12,22 @@ This function generates the story text and cover using OpenAI.
 {
   "story_id": "<uuid>",
   "theme": "Adventure in the woods",
-  "characters": [{"id": "<uuid>", "name": "Luna"}],
+"characters": [{
+  "id": "<uuid>",
+  "name": "Luna",
+  "age": "7",
+  "thumbnail_url": "https://..."
+}],
   "target_age": "5-7",
   "literary_style": "Narrativo",
   "central_message": "La amistad es lo más importante",
-  "additional_details": ""
+"additional_details": ""
 }
 ```
+
+The `thumbnail_url` values are used as reference images when generating the
+cover so the characters match their thumbnails. All images are produced with
+`gpt-image-1` using a fixed size and standard quality.
 
 ## Response
 

--- a/src/pages/MyStories.tsx
+++ b/src/pages/MyStories.tsx
@@ -35,7 +35,7 @@ const MyStories: React.FC = () => {
       if (error) throw error;
 
       const ids = (data || []).map((s) => s.id);
-      let covers: Record<string, string> = {};
+      const covers: Record<string, string> = {};
       if (ids.length > 0) {
         const { data: pages } = await supabase
           .from('story_pages')

--- a/src/services/storyService.ts
+++ b/src/services/storyService.ts
@@ -42,7 +42,7 @@ export const storyService = {
   async generateStory(params: {
     storyId: string;
     theme: string;
-    characters: { id?: string; name: string }[];
+    characters: { id?: string; name: string; age?: string; thumbnailUrl?: string | null }[];
     settings: {
       targetAge: string;
       literaryStyle: string;

--- a/supabase/functions/generate-spreads/index.ts
+++ b/supabase/functions/generate-spreads/index.ts
@@ -12,7 +12,7 @@ Deno.serve(async (req) => {
   }
 
   try {
-    const { prompts } = await req.json();
+    const { prompts, referenceImageIds = [] } = await req.json();
     
     const openai = new OpenAI({
       apiKey: Deno.env.get('OPENAI_API_KEY'),
@@ -22,15 +22,16 @@ Deno.serve(async (req) => {
       prompts.map(async (prompt: string) => {
         const start = Date.now();
         const response = await openai.images.generate({
-          model: "dall-e-3",
+          model: "gpt-image-1",
           prompt,
-          size: "2362x4724",
-          quality: "hd",
+          size: "1024x1024",
+          quality: "standard",
           n: 1,
+          referenced_image_ids: referenceImageIds,
         });
         const elapsed = Date.now() - start;
         await logPromptMetric({
-          modelo_ia: 'dall-e-3',
+          modelo_ia: 'gpt-image-1',
           tiempo_respuesta_ms: elapsed,
           estado: response.data?.[0]?.url ? 'success' : 'error',
           error_type: response.data?.[0]?.url ? null : 'service_error',

--- a/supabase/functions/generate-story/index.ts
+++ b/supabase/functions/generate-story/index.ts
@@ -45,6 +45,10 @@ Deno.serve(async (req) => {
     const charNames = characters
       .map((c: any) => `${c.name} de ${c.age} años`)
       .join(', ');
+
+    const charThumbnails = characters
+      .map((c: any) => c.thumbnailUrl || c.thumbnail_url)
+      .filter((u: string | null | undefined) => !!u) as string[];
     
     // Usar solo el tema como historia
     const storyTheme = theme || 'Sin tema específico';
@@ -167,10 +171,11 @@ Deno.serve(async (req) => {
       const coverRes = await openai.images.generate({
         model: 'gpt-image-1',
         prompt: promptText,
-        size: '1792x1024',
+        size: '1024x1024',
         n: 1,
         style: 'vivid',
-        quality: 'standard'
+        quality: 'standard',
+        referenced_image_ids: charThumbnails,
       });
       const celapsed = Date.now() - cstart;
       await logPromptMetric({


### PR DESCRIPTION
## Summary
- standardize story generation payload to include thumbnail URLs
- use thumbnails as reference images when generating the cover
- update spreads generation to rely on the same image model
- adjust MyStories and story service typing
- document new thumbnail-based workflow

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_683dff1314e8832ab110fe053a8d9f1d