### PR TITLE
Ensure consistent image generation

### DIFF
--- a/supabase/functions/generate-illustration/index.ts
+++ b/supabase/functions/generate-illustration/index.ts
@@ -1,4 +1,3 @@
-import OpenAI from "npm:openai@4.28.0";
 import { GenerateIllustrationParams } from "./types.ts";
 import { logPromptMetric } from '../_shared/metrics.ts';
 
@@ -59,16 +58,23 @@ Deno.serve(async (req) => {
       Ilustración para libro infantil.
     `.trim();
 
-    const openai = new OpenAI({ apiKey: Deno.env.get("OPENAI_API_KEY")! });
-
     const start = Date.now();
-    const response = await openai.images.generate({
-      model: "gpt-image-1",
-      prompt,
-      size: apiSize,
-      n: 1,
-      referenced_image_ids: referencedImageIds,
+    const res = await fetch('https://api.openai.com/v1/images/generations', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${Deno.env.get('OPENAI_API_KEY')}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-image-1',
+        prompt,
+        size: apiSize,
+        quality: 'hd',
+        n: 1,
+        referenced_image_ids: referencedImageIds,
+      }),
     });
+    const response = await res.json();
     const elapsed = Date.now() - start;
     await logPromptMetric({
       modelo_ia: "gpt-image-1",

--- a/supabase/functions/generate-spreads/index.ts
+++ b/supabase/functions/generate-spreads/index.ts
@@ -1,4 +1,4 @@
-import OpenAI from 'npm:openai@4.28.0';
+
 import { logPromptMetric } from '../_shared/metrics.ts';
 
 const corsHeaders = {
@@ -14,21 +14,25 @@ Deno.serve(async (req) => {
   try {
     const { prompts, referenceImageIds = [] } = await req.json();
     
-    const openai = new OpenAI({
-      apiKey: Deno.env.get('OPENAI_API_KEY'),
-    });
-
     const images = await Promise.all(
       prompts.map(async (prompt: string) => {
         const start = Date.now();
-        const response = await openai.images.generate({
-          model: "gpt-image-1",
-          prompt,
-          size: "1024x1024",
-          quality: "standard",
-          n: 1,
-          referenced_image_ids: referenceImageIds,
+        const res = await fetch('https://api.openai.com/v1/images/generations', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${Deno.env.get('OPENAI_API_KEY')}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: 'gpt-image-1',
+            prompt,
+            size: '1024x1024',
+            quality: 'hd',
+            n: 1,
+            referenced_image_ids: referenceImageIds,
+          }),
         });
+        const response = await res.json();
         const elapsed = Date.now() - start;
         await logPromptMetric({
           modelo_ia: 'gpt-image-1',

--- a/supabase/functions/generate-variations/index.ts
+++ b/supabase/functions/generate-variations/index.ts
@@ -1,4 +1,3 @@
-import OpenAI from 'npm:openai@4.28.0';
 import { logPromptMetric } from '../_shared/metrics.ts';
 
 const corsHeaders = {
@@ -14,23 +13,26 @@ Deno.serve(async (req) => {
   try {
     const { name, description, age } = await req.json();
     
-    const openai = new OpenAI({
-      apiKey: Deno.env.get('OPENAI_API_KEY'),
-    });
-
-    // Generate new thumbnail
     const start = Date.now();
-    const imageResponse = await openai.images.generate({
-      model: "dall-e-2",
-      prompt: `Clean full-body pencil sketch illustration for a children's book. ` +
-        `Character: ${age}. ${description}. Simple lines, no background, child-friendly.`,
-      size: "256x256",
-      //quality: "standard",
-      n: 1,
+    const res = await fetch('https://api.openai.com/v1/images/generations', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${Deno.env.get('OPENAI_API_KEY')}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-image-1',
+        prompt: `Clean full-body pencil sketch illustration for a children's book. ` +
+          `Character: ${age}. ${description}. Simple lines, no background, child-friendly.`,
+        size: '1024x1024',
+        quality: 'hd',
+        n: 1,
+      }),
     });
+    const imageResponse = await res.json();
     const elapsed = Date.now() - start;
     await logPromptMetric({
-      modelo_ia: 'dall-e-2',
+      modelo_ia: 'gpt-image-1',
       tiempo_respuesta_ms: elapsed,
       estado: imageResponse.data?.[0]?.url ? 'success' : 'error',
       error_type: imageResponse.data?.[0]?.url ? null : 'service_error',


### PR DESCRIPTION
## Summary
- refactor story cover creation to call the API directly using `quality: 'hd'`
- refactor scene, spreads, illustration and variation functions to use the same gpt-image-1 parameters

## Testing
- `npm run test:e2e` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_b_683e0b48869c832aa3da752c06e733e1