### PR TITLE
Implement wizard state persistence

### DIFF
--- a/src/components/Wizard/steps/StoryStep.tsx
+++ b/src/components/Wizard/steps/StoryStep.tsx
@@ -30,6 +30,10 @@ const StoryStep: React.FC = () => {
       });
       if (result && result.title && Array.isArray(result.paragraphs)) {
         setGenerated(result);
+        setStorySettings({
+          ...storySettings,
+          additionalDetails: result.paragraphs.join('\n\n')
+        });
       } else {
         alert('Respuesta inválida');
       }


### PR DESCRIPTION
## Summary
- allow recovering wizard data and last step from localStorage or Supabase
- autosave wizard progress back to localStorage
- expose `getStoryDraft` in `storyService`
- save generated text when creating the story

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_683e14f7161c832abe57227df92ca0b6