### PR TITLE
Implement async cover generation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,9 @@ import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'r
 import { AuthProvider } from './context/AuthContext';
 import { AdminProvider } from './context/AdminContext';
 import { WizardProvider } from './context/WizardContext';
+import { StoryProvider } from './context/StoryContext';
 import { useAuth } from './context/AuthContext';
-import Wizard from './components/Wizard/Wizard';
+import StoryCreationWizard from './pages/StoryCreationWizard';
 import Header from './components/Layout/Header';
 import Sidebar from './components/Layout/Sidebar';
 import LoginForm from './components/Auth/LoginForm';
@@ -51,6 +52,7 @@ function AnimatedRoutes() {
 
   return (
     <WizardProvider>
+      <StoryProvider>
       <AnimatePresence mode="wait">
         <motion.div
           key={location.pathname}
@@ -73,7 +75,7 @@ function AnimatedRoutes() {
                   path="/wizard/:storyId"
                   element={
                     <PrivateRoute>
-                      <Wizard />
+                      <StoryCreationWizard />
                     </PrivateRoute>
                   }
                 />
@@ -143,6 +145,7 @@ function AnimatedRoutes() {
           <ToastContainer />
         </motion.div>
       </AnimatePresence>
+      </StoryProvider>
     </WizardProvider>
   );
 }

--- a/src/components/StoryCard.tsx
+++ b/src/components/StoryCard.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { BookOpen, Pencil, Trash2, Loader } from 'lucide-react';
+import { useStory } from '../context/StoryContext';
+
+interface StoryCardProps {
+  story: {
+    id: string;
+    title: string;
+    created_at: string;
+    status: 'draft' | 'completed';
+    cover_url: string;
+  };
+  onContinue: (id: string) => void;
+  onRead: (id: string) => void;
+  onDelete: (story: any) => void;
+}
+
+const StoryCard: React.FC<StoryCardProps> = ({ story, onContinue, onRead, onDelete }) => {
+  const { covers } = useStory();
+  const state = covers[story.id];
+
+  const imageUrl = state?.url || story.cover_url;
+  const isLoading = state?.status === 'generating';
+
+  return (
+    <div className="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:scale-[1.02]">
+      <div className="aspect-video bg-gray-100 relative">
+        {imageUrl ? (
+          <img src={imageUrl} alt={story.title} loading="lazy" className="w-full h-full object-cover" />
+        ) : (
+          <div className="w-full h-full bg-gray-200" />
+        )}
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-white/60">
+            <Loader className="w-6 h-6 animate-spin text-purple-600" />
+          </div>
+        )}
+      </div>
+      <div className="p-4">
+        <div className="flex items-start justify-between mb-2">
+          <h3 className="text-lg font-semibold text-gray-800">{story.title}</h3>
+          {story.status === 'draft' && (
+            <span className="px-2 py-1 text-xs font-medium bg-yellow-100 text-yellow-800 rounded-full">
+              Borrador
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-gray-500 mb-4">
+          {new Date(story.created_at).toLocaleDateString()}
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={() => onRead(story.id)}
+            className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+          >
+            <BookOpen className="w-4 h-4" />
+            <span>Leer</span>
+          </button>
+          {story.status === 'draft' && (
+            <button
+              onClick={() => onContinue(story.id)}
+              className="flex-1 flex items-center justify-center gap-2 px-4 py-2 border border-purple-600 text-purple-600 rounded-lg hover:bg-purple-50 transition-colors"
+            >
+              <Pencil className="w-4 h-4" />
+              <span>Continuar</span>
+            </button>
+          )}
+          <button
+            onClick={() => onDelete(story)}
+            className="flex items-center justify-center px-4 py-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StoryCard;

--- a/src/context/StoryContext.tsx
+++ b/src/context/StoryContext.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useState } from 'react';
+import { useAuth } from './AuthContext';
+
+interface CoverInfo {
+  status: 'idle' | 'generating' | 'ready' | 'error';
+  url?: string;
+  error?: string;
+}
+
+interface StoryContextType {
+  covers: Record<string, CoverInfo>;
+  generateCover: (storyId: string, title: string, opts?: { style?: string; palette?: string; refIds?: string[] }) => Promise<void>;
+}
+
+const StoryContext = createContext<StoryContextType | undefined>(undefined);
+
+export const useStory = () => {
+  const ctx = useContext(StoryContext);
+  if (!ctx) throw new Error('useStory must be used within StoryProvider');
+  return ctx;
+};
+
+export const StoryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { supabase } = useAuth();
+  const [covers, setCovers] = useState<Record<string, CoverInfo>>({});
+
+  const generateCover = async (
+    storyId: string,
+    title: string,
+    opts?: { style?: string; palette?: string; refIds?: string[] }
+  ) => {
+    setCovers(prev => ({ ...prev, [storyId]: { status: 'generating' } }));
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+      const res = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-cover`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          story_id: storyId,
+          title,
+          visual_style: opts?.style,
+          color_palette: opts?.palette,
+          reference_image_ids: opts?.refIds || []
+        })
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Cover generation failed');
+
+      setCovers(prev => ({ ...prev, [storyId]: { status: 'ready', url: data.coverUrl } }));
+    } catch (err) {
+      console.error('Error generating cover:', err);
+      setCovers(prev => ({ ...prev, [storyId]: { status: 'error', error: (err as Error).message } }));
+    }
+  };
+
+  return (
+    <StoryContext.Provider value={{ covers, generateCover }}>
+      {children}
+    </StoryContext.Provider>
+  );
+};

--- a/src/pages/MyStories.tsx
+++ b/src/pages/MyStories.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
-import { Plus, BookOpen, Pencil, Trash2 } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import ConfirmDialog from '../components/UI/ConfirmDialog';
 import { storyService } from '../services/storyService';
 import { useNavigate } from 'react-router-dom';
+import StoryCard from '../components/StoryCard';
 
 interface Story {
   id: string;
@@ -113,60 +114,13 @@ const MyStories: React.FC = () => {
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {stories.map((story) => (
-            <div
+            <StoryCard
               key={story.id}
-              className="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:scale-[1.02]"
-            >
-              <div className="aspect-video bg-gray-100">
-                {story.cover_url ? (
-                  <img
-                    src={story.cover_url}
-                    alt={story.title}
-                    loading="lazy"
-                    className="w-full h-full object-cover"
-                  />
-                ) : (
-                  <div className="w-full h-full animate-pulse bg-gray-200" />
-                )}
-              </div>
-              <div className="p-4">
-                <div className="flex items-start justify-between mb-2">
-                  <h3 className="text-lg font-semibold text-gray-800">{story.title}</h3>
-                  {story.status === 'draft' && (
-                    <span className="px-2 py-1 text-xs font-medium bg-yellow-100 text-yellow-800 rounded-full">
-                      Borrador
-                    </span>
-                  )}
-                </div>
-                <p className="text-sm text-gray-500 mb-4">
-                  {new Date(story.created_at).toLocaleDateString()}
-                </p>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => handleReadStory(story.id)}
-                    className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
-                  >
-                    <BookOpen className="w-4 h-4" />
-                    <span>Leer</span>
-                  </button>
-                  {story.status === 'draft' && (
-                    <button
-                      onClick={() => handleContinueStory(story.id)}
-                      className="flex-1 flex items-center justify-center gap-2 px-4 py-2 border border-purple-600 text-purple-600 rounded-lg hover:bg-purple-50 transition-colors"
-                    >
-                      <Pencil className="w-4 h-4" />
-                      <span>Continuar</span>
-                    </button>
-                  )}
-                  <button
-                    onClick={() => handleDeleteClick(story)}
-                    className="flex items-center justify-center px-4 py-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-            </div>
+              story={story}
+              onContinue={handleContinueStory}
+              onRead={handleReadStory}
+              onDelete={handleDeleteClick}
+            />
           ))}
         </div>
 

--- a/src/pages/StoryCreationWizard.tsx
+++ b/src/pages/StoryCreationWizard.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import Wizard from '../components/Wizard/Wizard';
+import { useWizard } from '../context/WizardContext';
+import { useStory } from '../context/StoryContext';
+
+const StoryCreationWizard: React.FC = () => {
+  const { storyId } = useParams();
+  const { designSettings, storySettings, currentStep } = useWizard();
+  const { generateCover } = useStory();
+  const [requested, setRequested] = useState(false);
+
+  useEffect(() => {
+    if (!requested && currentStep === 'export' && storyId) {
+      setRequested(true);
+      generateCover(storyId, storySettings.theme || storySettings.centralMessage || '');
+    }
+  }, [currentStep, requested, storyId]);
+
+  return <Wizard />;
+};
+
+export default StoryCreationWizard;

--- a/supabase/functions/generate-cover/index.ts
+++ b/supabase/functions/generate-cover/index.ts
@@ -1,0 +1,122 @@
+import { createClient } from 'npm:@supabase/supabase-js@2.39.7';
+import { logPromptMetric, getUserId } from '../_shared/metrics.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const supabaseAdmin = createClient(
+  Deno.env.get('SUPABASE_URL') ?? '',
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  { auth: { persistSession: false, autoRefreshToken: false } }
+);
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  let promptId: string | undefined;
+  let userId: string | null = null;
+  let start = Date.now();
+
+  try {
+    const { story_id, title, visual_style, color_palette, reference_image_ids } = await req.json();
+    if (!story_id || !title) {
+      throw new Error('Missing story_id or title');
+    }
+
+    userId = await getUserId(req);
+
+    const { data: promptRow } = await supabaseAdmin
+      .from('prompts')
+      .select('id, content')
+      .eq('type', 'PROMPT_CUENTO_PORTADA')
+      .single();
+    const basePrompt = promptRow?.content || '';
+    promptId = promptRow?.id;
+    if (!basePrompt) throw new Error('Prompt not found');
+
+    const prompt = basePrompt
+      .replace('{style}', visual_style || 'acuarela digital')
+      .replace('{palette}', color_palette || 'colores vibrantes')
+      .replace('{story}', title);
+
+    start = Date.now();
+    const res = await fetch('https://api.openai.com/v1/images/generations', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${Deno.env.get('OPENAI_API_KEY')}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-image-1',
+        prompt,
+        size: '1024x1024',
+        quality: 'hd',
+        n: 1,
+        referenced_image_ids: reference_image_ids || [],
+      }),
+    });
+    const data = await res.json();
+    const elapsed = Date.now() - start;
+    await logPromptMetric({
+      prompt_id: promptId,
+      modelo_ia: 'gpt-image-1',
+      tiempo_respuesta_ms: elapsed,
+      estado: data.data?.[0]?.url ? 'success' : 'error',
+      error_type: data.data?.[0]?.url ? null : 'service_error',
+      tokens_entrada: 0,
+      tokens_salida: 0,
+      usuario_id: userId,
+    });
+
+    if (!data.data?.[0]?.url) {
+      throw new Error(data.error?.message || 'No image generated');
+    }
+
+    const imgRes = await fetch(data.data[0].url);
+    const blob = await imgRes.blob();
+    const path = `covers/${story_id}.png`;
+    const { error: uploadError } = await supabaseAdmin.storage
+      .from('storage')
+      .upload(path, blob, { contentType: 'image/png', upsert: true });
+    if (uploadError) throw uploadError;
+
+    const { data: { publicUrl } } = supabaseAdmin.storage
+      .from('storage')
+      .getPublicUrl(path);
+
+    await supabaseAdmin.from('story_pages').upsert({
+      story_id,
+      page_number: 0,
+      text: title,
+      image_url: publicUrl,
+      prompt
+    }, { onConflict: 'story_id,page_number' });
+
+    return new Response(
+      JSON.stringify({ coverUrl: publicUrl }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    if (promptId) {
+      await logPromptMetric({
+        prompt_id: promptId,
+        modelo_ia: 'gpt-image-1',
+        tiempo_respuesta_ms: Date.now() - start,
+        estado: 'error',
+        error_type: 'service_error',
+        tokens_entrada: 0,
+        tokens_salida: 0,
+        usuario_id: userId,
+        metadatos: { error: (error as Error).message },
+      });
+    }
+    return new Response(
+      JSON.stringify({ error: (error as Error).message }),
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- create StoryContext to handle cover generation
- display cover status with new StoryCard component
- generate cover automatically via StoryCreationWizard
- expose new `generate-cover` edge function
- wire StoryProvider into App and update MyStories

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_683e17ed4e74832a80bb7d303ac2b49c