### PR TITLE
Store prompts per page and block navigation until cover ready

### DIFF
--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -241,7 +241,8 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
           storySettings.theme !== '' &&
           storySettings.targetAge !== '' &&
           storySettings.literaryStyle !== '' &&
-          storySettings.centralMessage !== ''
+          storySettings.centralMessage !== '' &&
+          generatedPages.length > 0
         );
       case 'design':
         return designSettings.visualStyle !== '' && designSettings.colorPalette !== '';

--- a/supabase/functions/generate-story/index.ts
+++ b/supabase/functions/generate-story/index.ts
@@ -115,12 +115,17 @@ Deno.serve(async (req) => {
 
     const title = result.titulo;
     const paginas = result.paginas;
-    
-    // Extraer los párrafos en orden
-    const paragraphs = Object.entries(paginas)
+
+    // Extraer texto y prompt por página en orden
+    const pages = Object.entries(paginas)
       .sort(([a], [b]) => parseInt(a) - parseInt(b))
-      .map(([_, page]: [string, any]) => page?.texto)
-      .filter(Boolean);
+      .map(([_, page]: [string, any]) => ({
+        texto: page?.texto,
+        prompt: page?.prompt || '',
+      }))
+      .filter(p => !!p.texto);
+
+    const paragraphs = pages.map(p => p.texto as string);
 
     if (paragraphs.length === 0) {
       throw new Error('La historia generada no contiene párrafos válidos');
@@ -142,13 +147,13 @@ Deno.serve(async (req) => {
       });
     }
 
-    for (let i = 0; i < paragraphs.length; i++) {
+    for (let i = 0; i < pages.length; i++) {
       await supabaseAdmin.from('story_pages').insert({
         story_id,
         page_number: i + 1,
-        text: paragraphs[i],
+        text: pages[i].texto,
         image_url: '',
-        prompt: '',
+        prompt: pages[i].prompt,
       });
     }
 


### PR DESCRIPTION
## Summary
- store the prompt for each story page when generating the story
- ensure design step isn't reachable until story and cover generation finishes

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_683e7c284994832a854a72a28b1f1923