### PR TITLE
Add metadata for all prompt types

### DIFF
--- a/.issues/20250603T1857 improvement_Ocultar configuracion y mostrar metadata en prompts.md
+++ b/.issues/20250603T1857 improvement_Ocultar configuracion y mostrar metadata en prompts.md
@@ -1,0 +1,34 @@
+Épica: Admin
+Categoría: improvement/UI
+Notas para devs: El objetivo es simplificar la interfaz de administración eliminando una sección de la barra lateral y mostrando más información en la gestión de prompts.
+
+Archivos afectados:
+- `src/components/Layout/Sidebar.tsx` (modificación)
+- `src/components/Prompts/PromptAccordion.tsx` (modificación)
+- `src/constants/promptMetadata.ts` (nuevo)
+
+🧠 Contexto:
+Actualmente el sidebar incluye la sección **Configuración del Sistema** que permite cambiar los motores de generación de imágenes. Esta sección no es necesaria para el uso diario y puede generar confusión. Por otro lado, en la vista de Prompts no se indica qué modelo de IA ni qué endpoint utiliza cada prompt, lo que dificulta su mantenimiento.
+
+📐 Objetivo:
+1. Eliminar visualmente la sección "Configuración del Sistema" del sidebar sin afectar la configuración almacenada ni la funcionalidad existente.
+2. Mostrar en cada acordeón de `Prompts` el endpoint de la API y el modelo utilizado para ese prompt. Esta información puede definirse en un mapa estático `promptMetadata` mientras no exista en la base de datos.
+
+✅ CRITERIOS DE ÉXITO (lo que sí debe ocurrir):
+- [ ] El sidebar ya no muestra la sección de configuración del sistema.
+- [ ] La aplicación se comporta igual que antes para los usuarios.
+- [ ] Cada acordeón de prompt incluye un texto con su endpoint y modelo correspondiente.
+- [ ] La estructura y estilo de la aplicación se mantienen consistentes.
+
+❌ CRITERIOS DE FALLA (lo que no debe ocurrir):
+- [ ] Borrar o modificar accidentalmente la configuración persistente de los motores.
+- [ ] Ocultar información crítica para el administrador fuera de la vista de Prompts.
+- [ ] Generar errores en la interfaz de Prompts por falta de datos de endpoint/modelo.
+
+🧪 QA / Casos de prueba esperados:
+1. Abrir la aplicación como administrador y comprobar que la barra lateral no muestra "Configuración del Sistema".
+2. Ingresar a la sección de "Prompts" y desplegar cada acordeón. Debe verse el contenido editable del prompt más la información de Endpoint y Modelo.
+3. Confirmar que al editar y guardar un prompt la información de endpoint y modelo permanece visible y la funcionalidad no cambia.
+
+EXTRAS:
+- Si en el futuro se almacena esta metadata en la base de datos, actualizar el mapa estático para obtenerla desde Supabase.

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -192,34 +192,6 @@ const Sidebar: React.FC = () => {
               </Link>
             </li>
           )}
-          {isAdmin && (
-            <li className="mt-4">
-              <div className="px-4 py-2">
-                <h3 className="text-sm font-medium text-gray-900 mb-2">Configuración del Sistema</h3>
-                
-                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-3">
-                  <div className="flex items-start gap-2">
-                    <AlertTriangle className="w-5 h-5 text-yellow-600 flex-shrink-0 mt-0.5" />
-                    <p className="text-xs text-yellow-800">
-                      ⚠️ ATENCIÓN: Su selección afectará el método de generación de imágenes para TODOS los usuarios del sistema
-                    </p>
-                  </div>
-                </div>
-
-                <div className="space-y-4">
-                  {renderEngineSelector('thumbnail', 'Motor para miniaturas')}
-                  {renderEngineSelector('variations', 'Motor para variaciones')}
-                  {renderEngineSelector('spriteSheet', 'Motor para sprite sheets')}
-                </div>
-
-                {settings && (
-                  <p className="mt-4 text-xs text-gray-500">
-                    Última actualización: {new Date(settings.last_updated).toLocaleString()}
-                  </p>
-                )}
-              </div>
-            </li>
-          )}
         </ul>
       </nav>
 

--- a/src/components/Prompts/PromptAccordion.tsx
+++ b/src/components/Prompts/PromptAccordion.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { ChevronDown } from 'lucide-react';
 import Button from '../UI/Button';
 import { Prompt } from '../../types/prompts';
+import { promptMetadata } from '../../constants/promptMetadata';
 
 interface PromptAccordionProps {
   prompt: Prompt;
@@ -66,6 +67,12 @@ const PromptAccordion: React.FC<PromptAccordionProps> = ({ prompt, onSave }) => 
             />
           ) : (
             <pre className="whitespace-pre-wrap text-sm">{prompt.content}</pre>
+          )}
+          {promptMetadata[prompt.type] && (
+            <p className="text-xs text-gray-500">
+              Endpoint: <code>{promptMetadata[prompt.type].endpoint}</code> | Modelo:{' '}
+              {promptMetadata[prompt.type].model}
+            </p>
           )}
           <div className="flex justify-end gap-2">
             {isEditing ? (

--- a/src/constants/promptMetadata.ts
+++ b/src/constants/promptMetadata.ts
@@ -1,0 +1,51 @@
+export interface PromptMetadata {
+  endpoint: string;
+  model: string;
+}
+
+export const promptMetadata: Record<string, PromptMetadata> = {
+  PROMPT_DESCRIPCION_PERSONAJE: {
+    endpoint: 'https://api.openai.com/v1/chat/completions',
+    model: 'gpt-4-turbo'
+  },
+  PROMPT_GENERADOR_CUENTOS: {
+    endpoint: 'https://api.openai.com/v1/chat/completions',
+    model: 'gpt-4-turbo'
+  },
+  PROMPT_CUENTO_PORTADA: {
+    endpoint: 'https://api.openai.com/v1/images/generations',
+    model: 'gpt-image-1'
+  },
+  PROMPT_CREAR_MINIATURA_PERSONAJE: {
+    endpoint: 'https://api.openai.com/v1/images/edits',
+    model: 'gpt-image-1'
+  },
+  PROMPT_ESTILO_KAWAII: {
+    endpoint: 'https://api.openai.com/v1/images/edits',
+    model: 'gpt-image-1'
+  },
+  PROMPT_ESTILO_ACUARELADIGITAL: {
+    endpoint: 'https://api.openai.com/v1/images/edits',
+    model: 'gpt-image-1'
+  },
+  PROMPT_ESTILO_BORDADO: {
+    endpoint: 'https://api.openai.com/v1/images/edits',
+    model: 'gpt-image-1'
+  },
+  PROMPT_ESTILO_MANO: {
+    endpoint: 'https://api.openai.com/v1/images/edits',
+    model: 'gpt-image-1'
+  },
+  PROMPT_ESTILO_RECORTES: {
+    endpoint: 'https://api.openai.com/v1/images/edits',
+    model: 'gpt-image-1'
+  },
+  PROMPT_VARIANTE_TRASERA: {
+    endpoint: 'https://api.openai.com/v1/images/edits',
+    model: 'gpt-image-1'
+  },
+  PROMPT_VARIANTE_LATERAL: {
+    endpoint: 'https://api.openai.com/v1/images/edits',
+    model: 'gpt-image-1'
+  }
+};


### PR DESCRIPTION
## Summary
- list every prompt type used in the project
- show API endpoint and model for each prompt

## Testing
- `npm run lint` *(fails: existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_683f44e05294832abd551d3a96780b3d