### PR TITLE
Implement wizard flow state model

### DIFF
--- a/docs/flow/wizard-states.md
+++ b/docs/flow/wizard-states.md
@@ -1,0 +1,50 @@
+# Modelo de Estados del Wizard
+
+Este documento describe el sistema de estados que gestiona el avance del usuario durante la creación de un cuento.
+
+## Estados disponibles
+
+Cada etapa del asistente puede encontrarse en uno de los siguientes estados:
+
+- `no_iniciada`
+- `borrador`
+- `completado`
+
+```ts
+export type EtapaEstado = 'no_iniciada' | 'borrador' | 'completado';
+```
+
+La estructura completa del flujo se define mediante la interfaz `EstadoFlujo`:
+
+```ts
+export interface EstadoFlujo {
+  personajes: {
+    estado: EtapaEstado;
+    personajesAsignados: number;
+  };
+  cuento: EtapaEstado;
+  diseno: EtapaEstado;
+  vistaPrevia: EtapaEstado;
+}
+```
+
+## Reglas principales
+
+1. **Transiciones válidas**
+   - No se puede avanzar a una etapa si la anterior no está en estado `completado`.
+   - Al asignar los tres personajes se marca automáticamente la etapa de personajes como `completado`.
+2. **Persistencia**
+   - El estado se guarda con `zustand` utilizando `localStorage`, permitiendo reanudar el progreso al volver a la aplicación.
+3. **Carga de datos**
+   - Al continuar desde el inicio se identifica la primera etapa en `borrador` y se navega a ella cargando la información guardada.
+
+## Uso
+
+El store `useWizardFlowStore` expone acciones para actualizar cada etapa y avanzar o retroceder entre ellas.
+
+```ts
+const { estado, setPersonajes, avanzarEtapa, regresarEtapa, resetEstado } = useWizardFlowStore();
+```
+
+Estas acciones pueden integrarse en los componentes del wizard para mantener el seguimiento del flujo de creación.
+

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -2,7 +2,8 @@ import React, { createContext, useContext, useState, useEffect, ReactNode } from
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 import { useAutosave } from '../hooks/useAutosave';
-import { Character, StorySettings, DesignSettings, WizardState } from '../types';
+import { Character, StorySettings, DesignSettings, WizardState, EstadoFlujo } from '../types';
+import { useWizardFlowStore } from '../stores/wizardFlowStore';
 import { storyService } from '../services/storyService';
 
 export type WizardStep = 'characters' | 'story' | 'design' | 'preview' | 'export';
@@ -63,6 +64,13 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const { storyId } = useParams();
   const navigate = useNavigate();
   const { supabase, user } = useAuth();
+  const {
+    estado,
+    setPersonajes,
+    avanzarEtapa,
+    regresarEtapa,
+    resetEstado,
+  } = useWizardFlowStore();
   const [state, setState] = useState<WizardState>(INITIAL_STATE);
   const [currentStep, setCurrentStep] = useState<WizardStep>('characters');
   const [characters, setCharacters] = useState<Character[]>([]);
@@ -81,6 +89,11 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
 
   useAutosave(state, storyId || null);
+
+  // Mantener sincronizado el conteo de personajes en el store de flujo
+  useEffect(() => {
+    setPersonajes(characters.length);
+  }, [characters, setPersonajes]);
 
   useEffect(() => {
     const loadDraft = async () => {
@@ -149,6 +162,18 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         else if (draft.story && draft.story.central_message) step = 'story';
         else if (draft.characters && draft.characters.length > 0) step = 'story';
         setCurrentStep(step);
+
+        if (draft.characters) setPersonajes(draft.characters.length);
+        if (step === 'story') {
+          avanzarEtapa('personajes');
+        } else if (step === 'design') {
+          avanzarEtapa('personajes');
+          avanzarEtapa('cuento');
+        } else if (step === 'preview') {
+          avanzarEtapa('personajes');
+          avanzarEtapa('cuento');
+          avanzarEtapa('diseno');
+        }
       } catch (error) {
         console.error('Error loading draft:', error);
       }
@@ -162,6 +187,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const nextStep = () => {
     const currentIndex = steps.indexOf(currentStep);
     if (currentIndex < steps.length - 1) {
+      avanzarEtapa(currentStep as keyof EstadoFlujo);
       setCurrentStep(steps[currentIndex + 1]);
     }
   };
@@ -169,6 +195,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const prevStep = () => {
     const currentIndex = steps.indexOf(currentStep);
     if (currentIndex > 0) {
+      regresarEtapa(currentStep as keyof EstadoFlujo);
       setCurrentStep(steps[currentIndex - 1]);
     }
   };
@@ -177,6 +204,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     setState(INITIAL_STATE);
     setCurrentStep('characters');
     setCharacters([]);
+    resetEstado();
     setStorySettings({
       theme: '',
       targetAge: '',

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -101,6 +101,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         return;
       }
 
+      console.log('[WizardFlow] loadDraft inicio');
       try {
         const savedState = localStorage.getItem(`story_draft_${storyId}`);
         if (savedState) {
@@ -112,6 +113,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
           if (parsed.designSettings) setDesignSettings(parsed.designSettings);
           if (parsed.characters) setCharacters(parsed.characters);
           if (parsed.generatedPages) setGeneratedPages(parsed.generatedPages);
+          console.log('[WizardFlow] borrador local cargado', useWizardFlowStore.getState().estado);
           return;
         }
 
@@ -156,6 +158,8 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
           setGeneratedPages(pages);
         }
 
+        console.log('[WizardFlow] borrador remoto cargado', useWizardFlowStore.getState().estado);
+
         let step: WizardStep = 'characters';
         if (draft.pages && draft.pages.length > 0) step = 'preview';
         else if (draft.design) step = 'design';
@@ -174,6 +178,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
           avanzarEtapa('cuento');
           avanzarEtapa('diseno');
         }
+        console.log('[WizardFlow] estado tras load', useWizardFlowStore.getState().estado);
       } catch (error) {
         console.error('Error loading draft:', error);
       }
@@ -218,6 +223,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     });
     setGeneratedPages([]);
     setIsGenerating(false);
+    console.log('[WizardFlow] resetWizard', useWizardFlowStore.getState().estado);
   };
 
   useEffect(() => {

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -188,11 +188,21 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   }, [storyId, user]);
 
   const steps: WizardStep[] = ['characters', 'story', 'design', 'preview', 'export'];
+  const stepMap: Record<WizardStep, keyof EstadoFlujo | null> = {
+    characters: 'personajes',
+    story: 'cuento',
+    design: 'diseno',
+    preview: 'vistaPrevia',
+    export: null,
+  };
 
   const nextStep = () => {
     const currentIndex = steps.indexOf(currentStep);
     if (currentIndex < steps.length - 1) {
-      avanzarEtapa(currentStep as keyof EstadoFlujo);
+      const etapa = stepMap[currentStep];
+      if (etapa) {
+        avanzarEtapa(etapa);
+      }
       setCurrentStep(steps[currentIndex + 1]);
     }
   };
@@ -200,7 +210,10 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const prevStep = () => {
     const currentIndex = steps.indexOf(currentStep);
     if (currentIndex > 0) {
-      regresarEtapa(currentStep as keyof EstadoFlujo);
+      const etapa = stepMap[currentStep];
+      if (etapa) {
+        regresarEtapa(etapa);
+      }
       setCurrentStep(steps[currentIndex - 1]);
     }
   };

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -95,6 +95,13 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     setPersonajes(characters.length);
   }, [characters, setPersonajes]);
 
+  const stepFromEstado = (estado: EstadoFlujo): WizardStep => {
+    if (estado.personajes.estado !== 'completado') return 'characters';
+    if (estado.cuento !== 'completado') return 'story';
+    if (estado.diseno !== 'completado') return 'design';
+    return 'preview';
+  };
+
   useEffect(() => {
     const loadDraft = async () => {
       if (!storyId || !user) {
@@ -108,12 +115,14 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
           const parsed = JSON.parse(savedState);
           if (parsed.state) setState(parsed.state);
           else setState(parsed);
-          if (parsed.currentStep) setCurrentStep(parsed.currentStep);
           if (parsed.storySettings) setStorySettings(parsed.storySettings);
           if (parsed.designSettings) setDesignSettings(parsed.designSettings);
           if (parsed.characters) setCharacters(parsed.characters);
           if (parsed.generatedPages) setGeneratedPages(parsed.generatedPages);
-          console.log('[WizardFlow] borrador local cargado', useWizardFlowStore.getState().estado);
+          const estadoActual = useWizardFlowStore.getState().estado;
+          const step = stepFromEstado(estadoActual);
+          setCurrentStep(step);
+          console.log('[WizardFlow] borrador local cargado', estadoActual);
           return;
         }
 
@@ -178,7 +187,10 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
           avanzarEtapa('cuento');
           avanzarEtapa('diseno');
         }
-        console.log('[WizardFlow] estado tras load', useWizardFlowStore.getState().estado);
+        const nuevoEstado = useWizardFlowStore.getState().estado;
+        const next = stepFromEstado(nuevoEstado);
+        setCurrentStep(next);
+        console.log('[WizardFlow] estado tras load', nuevoEstado);
       } catch (error) {
         console.error('Error loading draft:', error);
       }

--- a/src/stores/wizardFlowStore.ts
+++ b/src/stores/wizardFlowStore.ts
@@ -1,0 +1,95 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type EtapaEstado = 'no_iniciada' | 'borrador' | 'completado';
+
+export interface EstadoFlujo {
+  personajes: {
+    estado: EtapaEstado;
+    personajesAsignados: number;
+  };
+  cuento: EtapaEstado;
+  diseno: EtapaEstado;
+  vistaPrevia: EtapaEstado;
+}
+
+interface WizardFlowStore {
+  estado: EstadoFlujo;
+  setPersonajes: (count: number) => void;
+  avanzarEtapa: (etapa: keyof EstadoFlujo) => void;
+  regresarEtapa: (etapa: keyof EstadoFlujo) => void;
+  resetEstado: () => void;
+}
+
+const initialState: EstadoFlujo = {
+  personajes: { estado: 'no_iniciada', personajesAsignados: 0 },
+  cuento: 'no_iniciada',
+  diseno: 'no_iniciada',
+  vistaPrevia: 'no_iniciada'
+};
+
+export const useWizardFlowStore = create<WizardFlowStore>()(
+  persist(
+    (set, get) => ({
+      estado: initialState,
+      setPersonajes: (count) =>
+        set((state) => {
+          const nuevoEstado = { ...state.estado };
+          nuevoEstado.personajes.personajesAsignados = count;
+          if (count === 0) {
+            nuevoEstado.personajes.estado = 'no_iniciada';
+          } else if (count < 3) {
+            nuevoEstado.personajes.estado = 'borrador';
+          } else {
+            nuevoEstado.personajes.estado = 'completado';
+            if (nuevoEstado.cuento === 'no_iniciada') {
+              nuevoEstado.cuento = 'borrador';
+            }
+          }
+          return { estado: nuevoEstado };
+        }),
+      avanzarEtapa: (etapa) =>
+        set((state) => {
+          const nuevoEstado = { ...state.estado };
+          if (etapa === 'personajes') {
+            if (nuevoEstado.personajes.estado === 'borrador' || nuevoEstado.personajes.estado === 'completado') {
+              nuevoEstado.personajes.estado = 'completado';
+              nuevoEstado.cuento = 'borrador';
+            }
+          } else if (etapa === 'cuento') {
+            if (nuevoEstado.personajes.estado === 'completado' && nuevoEstado.cuento !== 'completado') {
+              nuevoEstado.cuento = 'completado';
+              nuevoEstado.diseno = 'borrador';
+            }
+          } else if (etapa === 'diseno') {
+            if (nuevoEstado.cuento === 'completado' && nuevoEstado.diseno !== 'completado') {
+              nuevoEstado.diseno = 'completado';
+              nuevoEstado.vistaPrevia = 'borrador';
+            }
+          } else if (etapa === 'vistaPrevia') {
+            if (nuevoEstado.diseno === 'completado') {
+              nuevoEstado.vistaPrevia = 'borrador';
+            }
+          }
+          return { estado: nuevoEstado };
+        }),
+      regresarEtapa: (etapa) =>
+        set((state) => {
+          const nuevoEstado = { ...state.estado };
+          if (etapa === 'cuento') {
+            nuevoEstado.cuento = 'borrador';
+          } else if (etapa === 'diseno') {
+            nuevoEstado.diseno = 'borrador';
+          } else if (etapa === 'vistaPrevia') {
+            nuevoEstado.vistaPrevia = 'borrador';
+          }
+          return { estado: nuevoEstado };
+        }),
+      resetEstado: () => set({ estado: initialState })
+    }),
+    {
+      name: 'wizard-flow-store'
+    }
+  )
+);
+

--- a/src/stores/wizardFlowStore.ts
+++ b/src/stores/wizardFlowStore.ts
@@ -13,6 +13,15 @@ export interface EstadoFlujo {
   vistaPrevia: EtapaEstado;
 }
 
+const logEstado = (estado: EstadoFlujo, accion: string) => {
+  console.log(`[WizardFlow] ${accion}`, {
+    personajes: estado.personajes.estado,
+    cuento: estado.cuento,
+    diseno: estado.diseno,
+    vistaPrevia: estado.vistaPrevia,
+  });
+};
+
 interface WizardFlowStore {
   estado: EstadoFlujo;
   setPersonajes: (count: number) => void;
@@ -46,6 +55,7 @@ export const useWizardFlowStore = create<WizardFlowStore>()(
               nuevoEstado.cuento = 'borrador';
             }
           }
+          logEstado(nuevoEstado, 'setPersonajes');
           return { estado: nuevoEstado };
         }),
       avanzarEtapa: (etapa) =>
@@ -71,6 +81,7 @@ export const useWizardFlowStore = create<WizardFlowStore>()(
               nuevoEstado.vistaPrevia = 'borrador';
             }
           }
+          logEstado(nuevoEstado, 'avanzarEtapa');
           return { estado: nuevoEstado };
         }),
       regresarEtapa: (etapa) =>
@@ -83,9 +94,13 @@ export const useWizardFlowStore = create<WizardFlowStore>()(
           } else if (etapa === 'vistaPrevia') {
             nuevoEstado.vistaPrevia = 'borrador';
           }
+          logEstado(nuevoEstado, 'regresarEtapa');
           return { estado: nuevoEstado };
         }),
-      resetEstado: () => set({ estado: initialState })
+      resetEstado: () => {
+        logEstado(initialState, 'resetEstado');
+        set({ estado: initialState });
+      }
     }),
     {
       name: 'wizard-flow-store'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,6 +81,20 @@ export interface WizardState {
   };
 }
 
+
+// --- Wizard Flow State Types ---
+export type EtapaEstado = 'no_iniciada' | 'borrador' | 'completado';
+
+export interface EstadoFlujo {
+  personajes: {
+    estado: EtapaEstado;
+    personajesAsignados: number;
+  };
+  cuento: EtapaEstado;
+  diseno: EtapaEstado;
+  vistaPrevia: EtapaEstado;
+}
+
 // Opciones disponibles para la configuración del cuento
 export const ageOptions = [
   { value: '3-5', label: '3 a 5 años' },


### PR DESCRIPTION
## Summary
- add `EstadoFlujo` types to describe wizard progress
- create `wizardFlowStore` with Zustand persistence
- document wizard state machine
- integrate flow store into `WizardContext`

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_683fa00f1754832abfa3ddd7391e7e07