### PR TITLE
Add loader storage for story generation

### DIFF
--- a/docs/tech/story-generation.md
+++ b/docs/tech/story-generation.md
@@ -43,3 +43,5 @@ cover so the characters match their thumbnails. All images are produced with
 The function stores the generated title in `stories`, creates nine records in
 `story_pages` (page 0 is the cover) and links the provided characters using the
 `link_character_to_story` RPC.
+If the prompt returns loader messages, they are saved as JSON in the
+`stories.loader` column for future use.

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -280,6 +280,7 @@ export type Database = {
           created_at: string | null
           id: string
           literary_style: string | null
+          loader: Json | null
           status: string
           target_age: string | null
           title: string
@@ -292,6 +293,7 @@ export type Database = {
           created_at?: string | null
           id?: string
           literary_style?: string | null
+          loader?: Json | null
           status?: string
           target_age?: string | null
           title: string
@@ -304,6 +306,7 @@ export type Database = {
           created_at?: string | null
           id?: string
           literary_style?: string | null
+          loader?: Json | null
           status?: string
           target_age?: string | null
           title?: string

--- a/supabase/functions/generate-story/index.ts
+++ b/supabase/functions/generate-story/index.ts
@@ -132,6 +132,7 @@ Deno.serve(async (req) => {
 
     const title = result.titulo;
     const paginas = result.paginas;
+    const loaderMessages = result.loader || result.loaders || null;
     const coverPromptBase = result.portada?.prompt || '';
 
     // Extraer texto y prompt por página en orden
@@ -153,6 +154,7 @@ Deno.serve(async (req) => {
       .update({
         title,
         status: 'draft',
+        loader: loaderMessages,
       })
       .eq('id', story_id);
 

--- a/supabase/migrations/20250626090000_add_loader_column_to_stories.sql
+++ b/supabase/migrations/20250626090000_add_loader_column_to_stories.sql
@@ -1,0 +1,2 @@
+-- Add loader column to stories table for storing loader messages in JSON format
+ALTER TABLE public.stories ADD COLUMN IF NOT EXISTS loader jsonb;


### PR DESCRIPTION
## Summary
- add loader column migration for stories
- support loader JSON field in types
- store loader messages in generate-story function
- document loader storage in story-generation docs

## Testing
- `npm run lint` *(fails: 61 errors, 15 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683fa6d4fb9c832ab8b51b2b46a7cc25