### PR TITLE
Add theme autosave and draft resume

### DIFF
--- a/.supabase-functions-cache.json
+++ b/.supabase-functions-cache.json
@@ -1,46 +1,46 @@
 {
   "analyze-character": {
-    "hash": "7fbcdf776d15cbcfc90a81b3eb1aa84d525179207c42812d18352d02117031c6",
-    "updatedAt": "2025-06-04T21:04:33.464Z"
+    "hash": "81db67f32144ae8383bef12791c250014b3f4a5ddef9015aba0366776dd0a73b",
+    "updatedAt": "2025-06-04T21:30:45.159Z"
   },
   "delete-test-stories": {
     "hash": "770bd727a8d4f5875d8f41ed76007516ebbdf884d20c081960848a2aeea84cec",
-    "updatedAt": "2025-06-04T21:04:37.758Z"
+    "updatedAt": "2025-06-04T21:30:48.585Z"
   },
   "describe-and-sketch": {
-    "hash": "e6b828445d7818b2f7882501cbe25a2fd596c4fee1988d7182df307cf828f9e3",
-    "updatedAt": "2025-06-04T21:04:41.953Z"
+    "hash": "b32a954588115963f63c492d511607c69613fa702b3fb263ca81798517a37967",
+    "updatedAt": "2025-06-04T21:30:52.665Z"
   },
   "generate-illustration": {
     "hash": "67f5628323dd3e3ba3882567576011634bea6b07368e56b156fdfa5b90e4db1d",
-    "updatedAt": "2025-06-04T21:04:48.745Z"
+    "updatedAt": "2025-06-04T21:31:00.644Z"
   },
   "generate-scene": {
     "hash": "0b712ddf8c3b4dde0552e94000d86ce1310865ebff95fe36ce0b387455b50720",
-    "updatedAt": "2025-06-04T21:04:52.152Z"
+    "updatedAt": "2025-06-04T21:31:04.004Z"
   },
   "generate-spreads": {
     "hash": "7f38ab0f30e4f2bfad0a0a9160d4d90592ae5f30abaf9202a308d41136312ef5",
-    "updatedAt": "2025-06-04T21:04:56.050Z"
+    "updatedAt": "2025-06-04T21:31:07.386Z"
   },
   "generate-thumbnail-variant": {
-    "hash": "ef695958ee67a803cc02e3f7b67e87d0b6c4958300bcd2489f2139c84e589d0a",
-    "updatedAt": "2025-06-04T21:05:03.193Z"
+    "hash": "ebde506ed6fcae6210b86718a31d3065300765736cf07d951894fcc3617d7d96",
+    "updatedAt": "2025-06-04T21:31:14.248Z"
   },
   "generate-variations": {
     "hash": "20034a2b9244ef1f3871f6c52a3bc9556b930f620ad7ef68e95e3114f96c88f6",
-    "updatedAt": "2025-06-04T21:05:06.792Z"
+    "updatedAt": "2025-06-04T21:31:17.543Z"
   },
   "send-reset-email": {
     "hash": "a0141c2fb36c1f0ab79af42fd7b3187b2d7aea605793cff0f68c98de2ca88e24",
-    "updatedAt": "2025-06-04T21:05:11.145Z"
+    "updatedAt": "2025-06-04T21:31:21.671Z"
   },
   "generate-story": {
     "hash": "317e5b0ab2c84cff9fa392deccd1f2b2ff1136e7fdb9fea6a5b99649773541cc",
-    "updatedAt": "2025-06-04T21:04:59.520Z"
+    "updatedAt": "2025-06-04T21:31:10.806Z"
   },
   "generate-cover": {
-    "hash": "e6fd56fab30468d616c869b582ba2595e7fdefafd9f7473c036870995dcd6f76",
-    "updatedAt": "2025-06-04T21:04:45.410Z"
+    "hash": "3bb018cd8248f1b82aaba516ab9fda73ceea2e53ae606f283c1a5f48509812a6",
+    "updatedAt": "2025-06-04T21:30:57.125Z"
   }
 }

--- a/.supabase-functions-cache.json
+++ b/.supabase-functions-cache.json
@@ -1,46 +1,46 @@
 {
   "analyze-character": {
     "hash": "7fbcdf776d15cbcfc90a81b3eb1aa84d525179207c42812d18352d02117031c6",
-    "updatedAt": "2025-06-04T20:33:31.383Z"
+    "updatedAt": "2025-06-04T21:04:33.464Z"
   },
   "delete-test-stories": {
     "hash": "770bd727a8d4f5875d8f41ed76007516ebbdf884d20c081960848a2aeea84cec",
-    "updatedAt": "2025-06-04T20:33:35.662Z"
+    "updatedAt": "2025-06-04T21:04:37.758Z"
   },
   "describe-and-sketch": {
     "hash": "e6b828445d7818b2f7882501cbe25a2fd596c4fee1988d7182df307cf828f9e3",
-    "updatedAt": "2025-06-04T20:33:39.699Z"
+    "updatedAt": "2025-06-04T21:04:41.953Z"
   },
   "generate-illustration": {
     "hash": "67f5628323dd3e3ba3882567576011634bea6b07368e56b156fdfa5b90e4db1d",
-    "updatedAt": "2025-06-04T20:33:49.503Z"
+    "updatedAt": "2025-06-04T21:04:48.745Z"
   },
   "generate-scene": {
     "hash": "0b712ddf8c3b4dde0552e94000d86ce1310865ebff95fe36ce0b387455b50720",
-    "updatedAt": "2025-06-04T20:33:56.069Z"
+    "updatedAt": "2025-06-04T21:04:52.152Z"
   },
   "generate-spreads": {
     "hash": "7f38ab0f30e4f2bfad0a0a9160d4d90592ae5f30abaf9202a308d41136312ef5",
-    "updatedAt": "2025-06-04T20:34:00.287Z"
+    "updatedAt": "2025-06-04T21:04:56.050Z"
   },
   "generate-thumbnail-variant": {
     "hash": "ef695958ee67a803cc02e3f7b67e87d0b6c4958300bcd2489f2139c84e589d0a",
-    "updatedAt": "2025-06-04T20:34:08.192Z"
+    "updatedAt": "2025-06-04T21:05:03.193Z"
   },
   "generate-variations": {
     "hash": "20034a2b9244ef1f3871f6c52a3bc9556b930f620ad7ef68e95e3114f96c88f6",
-    "updatedAt": "2025-06-04T20:34:12.856Z"
+    "updatedAt": "2025-06-04T21:05:06.792Z"
   },
   "send-reset-email": {
     "hash": "a0141c2fb36c1f0ab79af42fd7b3187b2d7aea605793cff0f68c98de2ca88e24",
-    "updatedAt": "2025-06-04T20:34:17.104Z"
+    "updatedAt": "2025-06-04T21:05:11.145Z"
   },
   "generate-story": {
     "hash": "317e5b0ab2c84cff9fa392deccd1f2b2ff1136e7fdb9fea6a5b99649773541cc",
-    "updatedAt": "2025-06-04T20:34:03.832Z"
+    "updatedAt": "2025-06-04T21:04:59.520Z"
   },
   "generate-cover": {
     "hash": "e6fd56fab30468d616c869b582ba2595e7fdefafd9f7473c036870995dcd6f76",
-    "updatedAt": "2025-06-04T20:33:45.889Z"
+    "updatedAt": "2025-06-04T21:04:45.410Z"
   }
 }

--- a/.supabase-functions-cache.json
+++ b/.supabase-functions-cache.json
@@ -1,46 +1,46 @@
 {
   "analyze-character": {
     "hash": "7fbcdf776d15cbcfc90a81b3eb1aa84d525179207c42812d18352d02117031c6",
-    "updatedAt": "2025-06-04T19:57:25.905Z"
+    "updatedAt": "2025-06-04T20:33:31.383Z"
   },
   "delete-test-stories": {
     "hash": "770bd727a8d4f5875d8f41ed76007516ebbdf884d20c081960848a2aeea84cec",
-    "updatedAt": "2025-06-04T19:57:30.445Z"
+    "updatedAt": "2025-06-04T20:33:35.662Z"
   },
   "describe-and-sketch": {
     "hash": "e6b828445d7818b2f7882501cbe25a2fd596c4fee1988d7182df307cf828f9e3",
-    "updatedAt": "2025-06-04T19:57:48.707Z"
+    "updatedAt": "2025-06-04T20:33:39.699Z"
   },
   "generate-illustration": {
     "hash": "67f5628323dd3e3ba3882567576011634bea6b07368e56b156fdfa5b90e4db1d",
-    "updatedAt": "2025-06-04T19:58:09.719Z"
+    "updatedAt": "2025-06-04T20:33:49.503Z"
   },
   "generate-scene": {
     "hash": "0b712ddf8c3b4dde0552e94000d86ce1310865ebff95fe36ce0b387455b50720",
-    "updatedAt": "2025-06-04T19:58:14.677Z"
+    "updatedAt": "2025-06-04T20:33:56.069Z"
   },
   "generate-spreads": {
     "hash": "7f38ab0f30e4f2bfad0a0a9160d4d90592ae5f30abaf9202a308d41136312ef5",
-    "updatedAt": "2025-06-04T19:58:27.237Z"
+    "updatedAt": "2025-06-04T20:34:00.287Z"
   },
   "generate-thumbnail-variant": {
-    "hash": "a44c29a43ec9e637adc9d4908690f56d3770cf6ffadb081e134ba4443f7b5149",
-    "updatedAt": "2025-06-04T19:58:36.792Z"
+    "hash": "ef695958ee67a803cc02e3f7b67e87d0b6c4958300bcd2489f2139c84e589d0a",
+    "updatedAt": "2025-06-04T20:34:08.192Z"
   },
   "generate-variations": {
     "hash": "20034a2b9244ef1f3871f6c52a3bc9556b930f620ad7ef68e95e3114f96c88f6",
-    "updatedAt": "2025-06-04T19:58:42.228Z"
+    "updatedAt": "2025-06-04T20:34:12.856Z"
   },
   "send-reset-email": {
     "hash": "a0141c2fb36c1f0ab79af42fd7b3187b2d7aea605793cff0f68c98de2ca88e24",
-    "updatedAt": "2025-06-04T19:58:48.902Z"
+    "updatedAt": "2025-06-04T20:34:17.104Z"
   },
   "generate-story": {
     "hash": "317e5b0ab2c84cff9fa392deccd1f2b2ff1136e7fdb9fea6a5b99649773541cc",
-    "updatedAt": "2025-06-04T19:58:32.007Z"
+    "updatedAt": "2025-06-04T20:34:03.832Z"
   },
   "generate-cover": {
     "hash": "e6fd56fab30468d616c869b582ba2595e7fdefafd9f7473c036870995dcd6f76",
-    "updatedAt": "2025-06-04T19:57:52.914Z"
+    "updatedAt": "2025-06-04T20:33:45.889Z"
   }
 }

--- a/docs/tech/ai-providers/README.md
+++ b/docs/tech/ai-providers/README.md
@@ -54,6 +54,16 @@ response = client.images.generate(
 - **Generación y Edición**: `https://api.bfl.ai/v1/flux-kontext-pro`
 - **Consulta de Resultados**: `https://api.bfl.ai/v1/get_result`
 
+Estos endpoints están registrados en `src/constants/aiProviderCatalog.ts` para
+facilitar su selección en la interfaz de administración.
+
+<Info>
+  A diferencia de OpenAI, las solicitudes a Flux devuelven un `request_id` y se
+  debe consultar el endpoint de resultados para obtener la imagen una vez lista.
+  Además se utiliza la cabecera `x-key` en lugar de `Authorization`.
+  El código maneja esta comunicación asíncrona dentro de las funciones de Supabase.
+</Info>
+
 ### Modelos Disponibles
 
 #### FLUX.1 Kontext [pro]
@@ -146,6 +156,14 @@ image.save('gato_astronauta.png')
 | Modelo Local           | ❌                       | ❌          | ✅               |
 | Costo                 | Por token                 | Por solicitud| Gratis (autoalojado) |
 | Latencia              | Media-Alta                | Media        | Depende del hardware |
+
+## Resumen de Endpoints y Modelos
+
+| Proveedor | Endpoints | Modelos |
+|-----------|-----------|---------|
+| **OpenAI** | `/v1/images/generations`, `/v1/images/edits`, `/v1/images/variations` | `gpt-image-1`, `dall-e-3`, `dall-e-2` |
+| **Flux** | `/v1/flux-kontext-pro`, `/v1/get_result` | `flux-kontext-pro` |
+| **Stable Diffusion** | `http://localhost:7860` | `stable-diffusion-3.5` |
 
 ## Recomendaciones
 

--- a/docs/tech/ai-providers/flux/Cookbook.md
+++ b/docs/tech/ai-providers/flux/Cookbook.md
@@ -1,0 +1,3381 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "BFL API",
+    "description": "Authorize with an API key from your user profile.",
+    "version": "0.0.1"
+  },
+  "paths": {
+    "/v1/get_result": {
+      "get": {
+        "tags": [
+          "Utility"
+        ],
+        "summary": "Get Result",
+        "description": "An endpoint for getting generation task result.",
+        "operationId": "get_result_v1_get_result_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.1": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX 1.1 [pro].",
+        "description": "Submits an image generation task with FLUX 1.1 [pro].",
+        "operationId": "flux_pro_1_1_v1_flux_pro_1_1_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FluxPro11Inputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Flux Pro 1 1 V1 Flux Pro 1 1 Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX.1 [pro].",
+        "description": "Submits an image generation task with the FLUX.1 [pro].",
+        "operationId": "flux_pro_v1_flux_pro_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FluxProInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Flux Pro V1 Flux Pro Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-dev": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX.1 [dev].",
+        "description": "Submits an image generation task with FLUX.1 [dev].",
+        "operationId": "flux_dev_v1_flux_dev_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FluxDevInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Flux Dev V1 Flux Dev Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.1-ultra": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX 1.1 [pro] with ultra mode and optional raw mode.",
+        "description": "Submits an image generation task with FLUX 1.1 [pro] with ultra mode and optional raw mode.",
+        "operationId": "generate_bigblue_v1_flux_pro_1_1_ultra_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FluxUltraInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Generate Bigblue V1 Flux Pro 1 1 Ultra Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.0-fill": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX.1 Fill [pro] using an input image and mask.",
+        "description": "Submits an image generation task with the FLUX.1 Fill [pro] model using an input image and mask. Mask can be applied to alpha channel or submitted as a separate image.",
+        "operationId": "fill_v1_flux_pro_1_0_fill_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FluxProFillInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Fill V1 Flux Pro 1 0 Fill Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.0-expand": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Expand an image by adding pixels on any side.",
+        "description": "Submits an image expansion task that adds the specified number of pixels to any combination of sides (top, bottom, left, right) while maintaining context.",
+        "operationId": "expand_v1_flux_pro_1_0_expand_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FluxProExpandInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Expand V1 Flux Pro 1 0 Expand Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.0-canny": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX.1 Canny [pro] using a control image.",
+        "description": "Submits an image generation task with FLUX.1 Canny [pro].",
+        "operationId": "pro_canny_v1_flux_pro_1_0_canny_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CannyInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Pro Canny V1 Flux Pro 1 0 Canny Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.0-depth": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX.1 Depth [pro] using a control image.",
+        "description": "Submits an image generation task with FLUX.1 Depth [pro].",
+        "operationId": "pro_depth_v1_flux_pro_1_0_depth_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DepthInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Pro Depth V1 Flux Pro 1 0 Depth Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/finetune_details": {
+      "get": {
+        "tags": [
+          "Utility"
+        ],
+        "summary": "Finetune Details",
+        "description": "Get details about the training parameters and other metadata connected to a specific finetune_id that was created by the user.",
+        "operationId": "finetune_details_v1_finetune_details_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "finetune_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Finetune Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FinetuneDetailResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/finetune": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Finetune",
+        "operationId": "finetune_v1_finetune_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FinetuneInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-finetuned": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX.1 [pro] finetune",
+        "description": "Submits an image generation task with FLUX.1 [pro] using a finetune.",
+        "operationId": "flux_pro_finetuned_v1_flux_pro_finetuned_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FluxProFinetuneInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Flux Pro Finetuned V1 Flux Pro Finetuned Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.0-depth-finetuned": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX.1 Depth [pro] finetune using a control image.",
+        "description": "Submits an image generation task with FLUX.1 Depth [pro] finetune.",
+        "operationId": "flux_pro_1_0_depth_finetuned_v1_flux_pro_1_0_depth_finetuned_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FinetuneDepthInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Flux Pro 1 0 Depth Finetuned V1 Flux Pro 1 0 Depth Finetuned Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.0-canny-finetuned": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX.1 Canny [pro] finetune using a control image.",
+        "description": "Submits an image generation task with FLUX.1 Canny [pro] finetune.",
+        "operationId": "flux_pro_1_0_canny_finetuned_v1_flux_pro_1_0_canny_finetuned_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FinetuneCannyInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Flux Pro 1 0 Canny Finetuned V1 Flux Pro 1 0 Canny Finetuned Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.0-fill-finetuned": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX.1 Fill [pro] finetune using an input image and mask.",
+        "description": "Submits an image generation task with the FLUX.1 Fill [pro] finetune model using an input image and mask. Mask can be applied to alpha channel or submitted as a separate image.",
+        "operationId": "flux_pro_1_0_fill_finetuned_v1_flux_pro_1_0_fill_finetuned_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FinetuneFluxProFillInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Flux Pro 1 0 Fill Finetuned V1 Flux Pro 1 0 Fill Finetuned Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/my_finetunes": {
+      "get": {
+        "tags": [
+          "Utility"
+        ],
+        "summary": "My Finetunes",
+        "description": "List all finetune_ids created by the user",
+        "operationId": "my_finetunes_v1_my_finetunes_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyFinetunesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/delete_finetune": {
+      "post": {
+        "tags": [
+          "Utility"
+        ],
+        "summary": "Delete Finetune",
+        "description": "Delete a finetune_id that was created by the user",
+        "operationId": "delete_finetune_v1_delete_finetune_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteFinetuneInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteFinetuneResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-pro-1.1-ultra-finetuned": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Generate an image with FLUX 1.1 [pro] finetune with ultra mode.",
+        "description": "Submits an image generation task with FLUX 1.1 [pro] finetune with ultra mode.",
+        "operationId": "generate_bigblue_finetuned_v1_flux_pro_1_1_ultra_finetuned_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FinetuneFluxUltraInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Generate Bigblue Finetuned V1 Flux Pro 1 1 Ultra Finetuned Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-kontext-pro": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Edit or create an image with Flux Kontext Pro",
+        "operationId": "generate_flux_kontext_pro_v1_flux_kontext_pro_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FluxKontextProInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Generate Flux Kontext Pro V1 Flux Kontext Pro Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/flux-kontext-max": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Edit or create an image with Flux Kontext Max",
+        "operationId": "generate_flux_kontext_max_v1_flux_kontext_max_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FluxKontextProInputs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AsyncResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AsyncWebhookResponse"
+                    }
+                  ],
+                  "title": "Response Generate Flux Kontext Max V1 Flux Kontext Max Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AsyncResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "polling_url": {
+            "type": "string",
+            "title": "Polling Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "polling_url"
+        ],
+        "title": "AsyncResponse"
+      },
+      "AsyncWebhookResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "webhook_url": {
+            "type": "string",
+            "title": "Webhook Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "webhook_url"
+        ],
+        "title": "AsyncWebhookResponse"
+      },
+      "CannyInputs": {
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "Text prompt for image generation",
+            "example": "ein fantastisches bild"
+          },
+          "control_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Control Image",
+            "description": "Base64 encoded image to use as control input if no preprocessed image is provided"
+          },
+          "preprocessed_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preprocessed Image",
+            "description": "Optional pre-processed image that will bypass the control preprocessing step"
+          },
+          "canny_low_threshold": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 500,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Canny Low Threshold",
+            "description": "Low threshold for Canny edge detection",
+            "default": 50
+          },
+          "canny_high_threshold": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 500,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Canny High Threshold",
+            "description": "High threshold for Canny edge detection",
+            "default": 200
+          },
+          "prompt_upsampling": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility",
+            "example": 42
+          },
+          "steps": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 50,
+                "minimum": 15
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Steps",
+            "description": "Number of steps for the image generation process",
+            "default": 50
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "guidance": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 100,
+                "minimum": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guidance",
+            "description": "Guidance strength for the image generation process",
+            "default": 30
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "title": "CannyInputs"
+      },
+      "DeleteFinetuneInputs": {
+        "properties": {
+          "finetune_id": {
+            "type": "string",
+            "title": "Finetune Id",
+            "description": "ID of the fine-tuned model you want to delete.",
+            "example": "my-finetune"
+          }
+        },
+        "type": "object",
+        "required": [
+          "finetune_id"
+        ],
+        "title": "DeleteFinetuneInputs"
+      },
+      "DeleteFinetuneResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Status of the deletion"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "description": "Message about the deletion"
+          },
+          "deleted_finetune_id": {
+            "type": "string",
+            "title": "Deleted Finetune Id",
+            "description": "ID of the deleted finetune"
+          },
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp",
+            "description": "Timestamp of the deletion"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "message",
+          "deleted_finetune_id",
+          "timestamp"
+        ],
+        "title": "DeleteFinetuneResponse"
+      },
+      "DepthInputs": {
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "Text prompt for image generation",
+            "example": "ein fantastisches bild"
+          },
+          "control_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Control Image",
+            "description": "Base64 encoded image to use as control input"
+          },
+          "preprocessed_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preprocessed Image",
+            "description": "Optional pre-processed image that will bypass the control preprocessing step"
+          },
+          "prompt_upsampling": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility",
+            "example": 42
+          },
+          "steps": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 50,
+                "minimum": 15
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Steps",
+            "description": "Number of steps for the image generation process",
+            "default": 50
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "guidance": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 100,
+                "minimum": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guidance",
+            "description": "Guidance strength for the image generation process",
+            "default": 15
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "title": "DepthInputs"
+      },
+      "FinetuneCannyInputs": {
+        "properties": {
+          "finetune_id": {
+            "type": "string",
+            "title": "Finetune Id",
+            "description": "ID of the fine-tuned model you want to use.",
+            "example": "my-finetune"
+          },
+          "finetune_strength": {
+            "type": "number",
+            "maximum": 2,
+            "minimum": 0,
+            "title": "Finetune Strength",
+            "description": "Strength of the fine-tuned model. 0.0 means no influence, 1.0 means full influence. Allowed values up to 2.0",
+            "default": 1.1
+          },
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "Text prompt for image generation",
+            "example": "ein fantastisches bild"
+          },
+          "canny_low_threshold": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 500,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Canny Low Threshold",
+            "description": "Low threshold for Canny edge detection",
+            "default": 50
+          },
+          "canny_high_threshold": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 500,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Canny High Threshold",
+            "description": "High threshold for Canny edge detection",
+            "default": 200
+          },
+          "control_image": {
+            "type": "string",
+            "title": "Control Image",
+            "description": "Base64 encoded image to use as control input"
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility",
+            "example": 42
+          },
+          "steps": {
+            "type": "integer",
+            "maximum": 50,
+            "minimum": 15,
+            "title": "Steps",
+            "description": "Number of steps for the image generation process",
+            "default": 50
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "guidance": {
+            "type": "number",
+            "maximum": 100,
+            "minimum": 1,
+            "title": "Guidance",
+            "description": "Guidance strength for the image generation process",
+            "default": 30
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "finetune_id",
+          "prompt",
+          "control_image"
+        ],
+        "title": "FinetuneCannyInputs"
+      },
+      "FinetuneDepthInputs": {
+        "properties": {
+          "finetune_id": {
+            "type": "string",
+            "title": "Finetune Id",
+            "description": "ID of the fine-tuned model you want to use.",
+            "example": "my-finetune"
+          },
+          "finetune_strength": {
+            "type": "number",
+            "maximum": 2,
+            "minimum": 0,
+            "title": "Finetune Strength",
+            "description": "Strength of the fine-tuned model. 0.0 means no influence, 1.0 means full influence. Allowed values up to 2.0",
+            "default": 1.1
+          },
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "Text prompt for image generation",
+            "example": "ein fantastisches bild"
+          },
+          "control_image": {
+            "type": "string",
+            "title": "Control Image",
+            "description": "Base64 encoded image to use as control input"
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility",
+            "example": 42
+          },
+          "steps": {
+            "type": "integer",
+            "maximum": 50,
+            "minimum": 15,
+            "title": "Steps",
+            "description": "Number of steps for the image generation process",
+            "default": 50
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "guidance": {
+            "type": "number",
+            "maximum": 100,
+            "minimum": 1,
+            "title": "Guidance",
+            "description": "Guidance strength for the image generation process",
+            "default": 15
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "finetune_id",
+          "prompt",
+          "control_image"
+        ],
+        "title": "FinetuneDepthInputs"
+      },
+      "FinetuneDetailResponse": {
+        "properties": {
+          "finetune_details": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Finetune Details",
+            "description": "Details about the parameters used for finetuning"
+          }
+        },
+        "type": "object",
+        "required": [
+          "finetune_details"
+        ],
+        "title": "FinetuneDetailResponse"
+      },
+      "FinetuneFluxProFillInputs": {
+        "properties": {
+          "finetune_id": {
+            "type": "string",
+            "title": "Finetune Id",
+            "description": "ID of the fine-tuned model you want to use.",
+            "example": "my-finetune"
+          },
+          "finetune_strength": {
+            "type": "number",
+            "maximum": 2,
+            "minimum": 0,
+            "title": "Finetune Strength",
+            "description": "Strength of the fine-tuned model. 0.0 means no influence, 1.0 means full influence. Allowed values up to 2.0",
+            "default": 1.1
+          },
+          "image": {
+            "type": "string",
+            "title": "Image",
+            "description": "A Base64-encoded string representing the image you wish to modify. Can contain alpha mask if desired."
+          },
+          "mask": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mask",
+            "description": "A Base64-encoded string representing a mask for the areas you want to modify in the image. The mask should be the same dimensions as the image and in black and white. Black areas (0%) indicate no modification, while white areas (100%) specify areas for inpainting. Optional if you provide an alpha mask in the original image. Validation: The endpoint verifies that the dimensions of the mask match the original image."
+          },
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "The description of the changes you want to make. This text guides the inpainting process, allowing you to specify features, styles, or modifications for the masked area.",
+            "default": "",
+            "example": "ein fantastisches bild"
+          },
+          "steps": {
+            "type": "integer",
+            "maximum": 50,
+            "minimum": 15,
+            "title": "Steps",
+            "description": "Number of steps for the image generation process",
+            "default": 50,
+            "example": 50
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility"
+          },
+          "guidance": {
+            "type": "number",
+            "maximum": 100,
+            "minimum": 1.5,
+            "title": "Guidance",
+            "description": "Guidance strength for the image generation process",
+            "default": 60
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2,
+            "example": 2
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "finetune_id",
+          "image"
+        ],
+        "title": "FinetuneFluxProFillInputs"
+      },
+      "FinetuneFluxUltraInput": {
+        "properties": {
+          "finetune_id": {
+            "type": "string",
+            "title": "Finetune Id",
+            "description": "ID of the fine-tuned model you want to use.",
+            "example": "my-finetune"
+          },
+          "finetune_strength": {
+            "type": "number",
+            "maximum": 2,
+            "minimum": 0,
+            "title": "Finetune Strength",
+            "description": "Strength of the fine-tuned model. 0.0 means no influence, 1.0 means full influence. Allowed values up to 2.0",
+            "default": 1.2
+          },
+          "prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt",
+            "description": "The prompt to use for image generation.",
+            "default": "",
+            "example": "A beautiful landscape with mountains and a lake"
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility. If not provided, a random seed will be used.",
+            "example": 42
+          },
+          "aspect_ratio": {
+            "type": "string",
+            "title": "Aspect Ratio",
+            "description": "Aspect ratio of the image between 21:9 and 9:21",
+            "default": "16:9"
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2,
+            "example": 2
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "image_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Prompt",
+            "description": "Optional image to remix in base64 format"
+          },
+          "image_prompt_strength": {
+            "type": "number",
+            "maximum": 1,
+            "minimum": 0,
+            "title": "Image Prompt Strength",
+            "description": "Blend between the prompt and the image prompt",
+            "default": 0.1
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation",
+            "default": false
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "finetune_id"
+        ],
+        "title": "FinetuneFluxUltraInput"
+      },
+      "FinetuneInputs": {
+        "properties": {
+          "file_data": {
+            "type": "string",
+            "title": "File Data",
+            "description": "Base64-encoded ZIP file containing training images and, optionally, corresponding captions."
+          },
+          "finetune_comment": {
+            "type": "string",
+            "title": "Finetune Comment",
+            "description": "Comment or name of the fine-tuned model. This will be added as a field to the finetune_details.",
+            "example": "my-first-finetune"
+          },
+          "trigger_word": {
+            "type": "string",
+            "title": "Trigger Word",
+            "description": "Trigger word for the fine-tuned model.",
+            "default": "TOK",
+            "example": "TOK"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "general",
+              "character",
+              "style",
+              "product"
+            ],
+            "title": "Mode",
+            "description": "Mode for the fine-tuned model. Allowed values are 'general', 'character', 'style', 'product'. This will affect the caption behaviour. General will describe the image in full detail."
+          },
+          "iterations": {
+            "type": "integer",
+            "maximum": 1000,
+            "minimum": 100,
+            "title": "Iterations",
+            "description": "Number of iterations for fine-tuning.",
+            "default": 300
+          },
+          "learning_rate": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 0.005,
+                "minimum": 0.000001
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Learning Rate",
+            "description": "Learning rate for fine-tuning. If not provided, defaults to 1e-5 for full fine-tuning and 1e-4 for lora fine-tuning."
+          },
+          "captioning": {
+            "type": "boolean",
+            "title": "Captioning",
+            "description": "Whether to enable captioning during fine-tuning.",
+            "default": true
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "speed",
+              "quality",
+              "high_res_only"
+            ],
+            "title": "Priority",
+            "description": "Priority of the fine-tuning process. 'speed' will prioritize iteration speed over quality, 'quality' will prioritize quality over speed.",
+            "default": "quality"
+          },
+          "finetune_type": {
+            "type": "string",
+            "enum": [
+              "lora",
+              "full"
+            ],
+            "title": "Finetune Type",
+            "description": "Type of fine-tuning. 'lora' is a standard LoRA Adapter, 'full' is a full fine-tuning mode, with a post hoc lora extraction.",
+            "default": "full"
+          },
+          "lora_rank": {
+            "type": "integer",
+            "enum": [
+              16,
+              32
+            ],
+            "title": "Lora Rank",
+            "description": "Rank of the fine-tuned model. 16 or 32. If finetune_type is 'full', this will be the rank of the extracted lora model.",
+            "default": 32
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_data",
+          "finetune_comment",
+          "mode"
+        ],
+        "title": "FinetuneInputs"
+      },
+      "FluxDevInputs": {
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "Text prompt for image generation.",
+            "default": "",
+            "example": "ein fantastisches bild"
+          },
+          "image_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Prompt",
+            "description": "Optional base64 encoded image to use as a prompt for generation."
+          },
+          "width": {
+            "type": "integer",
+            "multipleOf": 32,
+            "maximum": 1440,
+            "minimum": 256,
+            "title": "Width",
+            "description": "Width of the generated image in pixels. Must be a multiple of 32.",
+            "default": 1024
+          },
+          "height": {
+            "type": "integer",
+            "multipleOf": 32,
+            "maximum": 1440,
+            "minimum": 256,
+            "title": "Height",
+            "description": "Height of the generated image in pixels. Must be a multiple of 32.",
+            "default": 768
+          },
+          "steps": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 50,
+                "minimum": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Steps",
+            "description": "Number of steps for the image generation process.",
+            "default": 28,
+            "example": 28
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation.",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility.",
+            "example": 42
+          },
+          "guidance": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 5,
+                "minimum": 1.5
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guidance",
+            "description": "Guidance scale for image generation. High guidance scales improve prompt adherence at the cost of reduced realism.",
+            "default": 3,
+            "example": 3
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2,
+            "example": 2
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "title": "FluxDevInputs"
+      },
+      "FluxKontextProInputs": {
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "Text prompt for image generation.",
+            "example": "ein fantastisches bild"
+          },
+          "input_image": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Image",
+            "description": "Base64 encoded image to use with Kontext."
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility.",
+            "example": 42
+          },
+          "aspect_ratio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aspect Ratio",
+            "description": "Aspect ratio of the image between 21:9 and 9:21"
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "png"
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation.",
+            "default": false
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict. Limit of 2 for Image to Image.",
+            "default": 2,
+            "example": 2
+          }
+        },
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "title": "FluxKontextProInputs"
+      },
+      "FluxPro11Inputs": {
+        "properties": {
+          "prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt",
+            "description": "Text prompt for image generation.",
+            "default": "",
+            "example": "ein fantastisches bild"
+          },
+          "image_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Prompt",
+            "description": "Optional base64 encoded image to use with Flux Redux."
+          },
+          "width": {
+            "type": "integer",
+            "multipleOf": 32,
+            "maximum": 1440,
+            "minimum": 256,
+            "title": "Width",
+            "description": "Width of the generated image in pixels. Must be a multiple of 32.",
+            "default": 1024
+          },
+          "height": {
+            "type": "integer",
+            "multipleOf": 32,
+            "maximum": 1440,
+            "minimum": 256,
+            "title": "Height",
+            "description": "Height of the generated image in pixels. Must be a multiple of 32.",
+            "default": 768
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation.",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility.",
+            "example": 42
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2,
+            "example": 2
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "title": "FluxPro11Inputs"
+      },
+      "FluxProExpandInputs": {
+        "properties": {
+          "image": {
+            "type": "string",
+            "title": "Image",
+            "description": "A Base64-encoded string representing the image you wish to expand."
+          },
+          "top": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 2048,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top",
+            "description": "Number of pixels to expand at the top of the image",
+            "default": 0
+          },
+          "bottom": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 2048,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bottom",
+            "description": "Number of pixels to expand at the bottom of the image",
+            "default": 0
+          },
+          "left": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 2048,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Left",
+            "description": "Number of pixels to expand on the left side of the image",
+            "default": 0
+          },
+          "right": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 2048,
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Right",
+            "description": "Number of pixels to expand on the right side of the image",
+            "default": 0
+          },
+          "prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt",
+            "description": "The description of the changes you want to make. This text guides the expansion process, allowing you to specify features, styles, or modifications for the expanded areas.",
+            "default": "",
+            "example": "ein fantastisches bild"
+          },
+          "steps": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 50,
+                "minimum": 15
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Steps",
+            "description": "Number of steps for the image generation process",
+            "default": 50,
+            "example": 50
+          },
+          "prompt_upsampling": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility"
+          },
+          "guidance": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 100,
+                "minimum": 1.5
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guidance",
+            "description": "Guidance strength for the image generation process",
+            "default": 60
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2,
+            "example": 2
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "image"
+        ],
+        "title": "FluxProExpandInputs"
+      },
+      "FluxProFillInputs": {
+        "properties": {
+          "image": {
+            "type": "string",
+            "title": "Image",
+            "description": "A Base64-encoded string representing the image you wish to modify. Can contain alpha mask if desired."
+          },
+          "mask": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mask",
+            "description": "A Base64-encoded string representing a mask for the areas you want to modify in the image. The mask should be the same dimensions as the image and in black and white. Black areas (0%) indicate no modification, while white areas (100%) specify areas for inpainting. Optional if you provide an alpha mask in the original image. Validation: The endpoint verifies that the dimensions of the mask match the original image."
+          },
+          "prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt",
+            "description": "The description of the changes you want to make. This text guides the inpainting process, allowing you to specify features, styles, or modifications for the masked area.",
+            "default": "",
+            "example": "ein fantastisches bild"
+          },
+          "steps": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 50,
+                "minimum": 15
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Steps",
+            "description": "Number of steps for the image generation process",
+            "default": 50,
+            "example": 50
+          },
+          "prompt_upsampling": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility"
+          },
+          "guidance": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 100,
+                "minimum": 1.5
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guidance",
+            "description": "Guidance strength for the image generation process",
+            "default": 60
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2,
+            "example": 2
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "image"
+        ],
+        "title": "FluxProFillInputs"
+      },
+      "FluxProFinetuneInputs": {
+        "properties": {
+          "finetune_id": {
+            "type": "string",
+            "title": "Finetune Id",
+            "description": "ID of the fine-tuned model you want to use.",
+            "example": "my-finetune"
+          },
+          "finetune_strength": {
+            "type": "number",
+            "maximum": 2,
+            "minimum": 0,
+            "title": "Finetune Strength",
+            "description": "Strength of the fine-tuned model. 0.0 means no influence, 1.0 means full influence. Allowed values up to 2.0",
+            "default": 1.1
+          },
+          "steps": {
+            "type": "integer",
+            "maximum": 50,
+            "minimum": 1,
+            "title": "Steps",
+            "description": "Number of steps for the fine-tuning process.",
+            "default": 40,
+            "example": 40
+          },
+          "guidance": {
+            "type": "number",
+            "maximum": 5,
+            "minimum": 1.5,
+            "title": "Guidance",
+            "description": "Guidance scale for image generation. High guidance scales improve prompt adherence at the cost of reduced realism.",
+            "default": 2.5,
+            "example": 2.5
+          },
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "Text prompt for image generation.",
+            "default": "",
+            "example": "ein fantastisches bild"
+          },
+          "image_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Prompt",
+            "description": "Optional base64 encoded image to use with Flux Redux."
+          },
+          "width": {
+            "type": "integer",
+            "multipleOf": 32,
+            "maximum": 1440,
+            "minimum": 256,
+            "title": "Width",
+            "description": "Width of the generated image in pixels. Must be a multiple of 32.",
+            "default": 1024
+          },
+          "height": {
+            "type": "integer",
+            "multipleOf": 32,
+            "maximum": 1440,
+            "minimum": 256,
+            "title": "Height",
+            "description": "Height of the generated image in pixels. Must be a multiple of 32.",
+            "default": 768
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation.",
+            "default": false
+          },
+          "seed": {
+            "type": "integer",
+            "title": "Seed",
+            "description": "Optional seed for reproducibility.",
+            "example": 42
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2,
+            "example": 2
+          },
+          "output_format": {
+            "$ref": "#/components/schemas/OutputFormat",
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "required": [
+          "finetune_id"
+        ],
+        "title": "FluxProFinetuneInputs"
+      },
+      "FluxProInputs": {
+        "properties": {
+          "prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt",
+            "description": "Text prompt for image generation.",
+            "default": "",
+            "example": "ein fantastisches bild"
+          },
+          "image_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Prompt",
+            "description": "Optional base64 encoded image to use as a prompt for generation."
+          },
+          "width": {
+            "type": "integer",
+            "multipleOf": 32,
+            "maximum": 1440,
+            "minimum": 256,
+            "title": "Width",
+            "description": "Width of the generated image in pixels. Must be a multiple of 32.",
+            "default": 1024
+          },
+          "height": {
+            "type": "integer",
+            "multipleOf": 32,
+            "maximum": 1440,
+            "minimum": 256,
+            "title": "Height",
+            "description": "Height of the generated image in pixels. Must be a multiple of 32.",
+            "default": 768
+          },
+          "steps": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 50,
+                "minimum": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Steps",
+            "description": "Number of steps for the image generation process.",
+            "default": 40,
+            "example": 40
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation.",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility.",
+            "example": 42
+          },
+          "guidance": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 5,
+                "minimum": 1.5
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guidance",
+            "description": "Guidance scale for image generation. High guidance scales improve prompt adherence at the cost of reduced realism.",
+            "default": 2.5,
+            "example": 2.5
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2,
+            "example": 2
+          },
+          "interval": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 4,
+                "minimum": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interval",
+            "description": "Interval parameter for guidance control.",
+            "default": 2,
+            "example": 2
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "title": "FluxProInputs"
+      },
+      "FluxUltraInput": {
+        "properties": {
+          "prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt",
+            "description": "The prompt to use for image generation.",
+            "default": "",
+            "example": "A beautiful landscape with mountains and a lake"
+          },
+          "prompt_upsampling": {
+            "type": "boolean",
+            "title": "Prompt Upsampling",
+            "description": "Whether to perform upsampling on the prompt. If active, automatically modifies the prompt for more creative generation.",
+            "default": false
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed",
+            "description": "Optional seed for reproducibility. If not provided, a random seed will be used.",
+            "example": 42
+          },
+          "aspect_ratio": {
+            "type": "string",
+            "title": "Aspect Ratio",
+            "description": "Aspect ratio of the image between 21:9 and 9:21",
+            "default": "16:9"
+          },
+          "safety_tolerance": {
+            "type": "integer",
+            "maximum": 6,
+            "minimum": 0,
+            "title": "Safety Tolerance",
+            "description": "Tolerance level for input and output moderation. Between 0 and 6, 0 being most strict, 6 being least strict.",
+            "default": 2,
+            "example": 2
+          },
+          "output_format": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputFormat"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Output format for the generated image. Can be 'jpeg' or 'png'.",
+            "default": "jpeg"
+          },
+          "raw": {
+            "type": "boolean",
+            "title": "Raw",
+            "description": "Generate less processed, more natural-looking images",
+            "default": false,
+            "example": false
+          },
+          "image_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Prompt",
+            "description": "Optional image to remix in base64 format"
+          },
+          "image_prompt_strength": {
+            "type": "number",
+            "maximum": 1,
+            "minimum": 0,
+            "title": "Image Prompt Strength",
+            "description": "Blend between the prompt and the image prompt",
+            "default": 0.1
+          },
+          "webhook_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Url",
+            "description": "URL to receive webhook notifications"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret",
+            "description": "Optional secret for webhook signature verification"
+          }
+        },
+        "type": "object",
+        "title": "FluxUltraInput"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "MyFinetunesResponse": {
+        "properties": {
+          "finetunes": {
+            "items": {},
+            "type": "array",
+            "title": "Finetunes",
+            "description": "List of finetunes created by the user"
+          }
+        },
+        "type": "object",
+        "required": [
+          "finetunes"
+        ],
+        "title": "MyFinetunesResponse"
+      },
+      "OutputFormat": {
+        "type": "string",
+        "enum": [
+          "jpeg",
+          "png"
+        ],
+        "title": "OutputFormat"
+      },
+      "ResultResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Task id for retrieving result"
+          },
+          "status": {
+            "$ref": "#/components/schemas/StatusResponse"
+          },
+          "result": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Progress"
+          },
+          "details": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Details"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status"
+        ],
+        "title": "ResultResponse"
+      },
+      "StatusResponse": {
+        "type": "string",
+        "enum": [
+          "Task not found",
+          "Pending",
+          "Request Moderated",
+          "Content Moderated",
+          "Ready",
+          "Error"
+        ],
+        "title": "StatusResponse"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "APIKeyHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-key"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Utility",
+      "description": "These utility endpoints allow you to check the results of submitted tasks and to manage your finetunes."
+    },
+    {
+      "name": "Tasks",
+      "description": "Generation task endpoints. These endpoints allow you to submit generation tasks."
+    }
+  ]
+}

--- a/docs/tech/ai-providers/flux/README.md
+++ b/docs/tech/ai-providers/flux/README.md
@@ -442,5 +442,20 @@ List of Kontext parameters for image editing via the `/flux-kontext-pro` endpoin
 | `seed`             | Optional seed for reproducibility             | None     | Any integer   |
 | `safety_tolerance` | Moderation level (0=strict, 6=permissive)     | 2        | 0-6           |
 | `output_format`    | Format of the output image                    | "jpeg"   | "jpeg", "png" |
-| `webhook_url`      | URL for asynchronous completion notification  | None     | Valid URL     |
-| `webhook_secret`   | Secret for webhook signature verification     | None     | String        |
+| `safety_filter`    | Whether to apply safety filters              | true     | boolean       |
+| `store`            | Whether to store the generated image        | true     | boolean       |
+
+## Referencia de la API
+
+Para una documentación más detallada de la API de Flux, incluyendo todos los endpoints disponibles, parámetros y esquemas de solicitud/respuesta, consulta el [Cookbook de la API de Flux](./Cookbook.md).
+
+La documentación completa incluye:
+
+- Especificación OpenAPI 3.1.0 completa
+- Descripción detallada de todos los endpoints
+- Esquemas de solicitud y respuesta
+- Códigos de estado HTTP
+- Esquemas de autenticación
+- Ejemplos de solicitudes y respuestas
+
+Esta documentación es especialmente útil para desarrolladores que necesitan integrar la API de Flux en sus aplicaciones o para entender en profundidad las capacidades del sistema.

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -3,7 +3,7 @@ import { BookOpen, User, Settings, LogOut, AlertTriangle, BarChart3, Home } from
 import { useAuth } from '../../context/AuthContext';
 import { useAdmin } from '../../context/AdminContext';
 import { Link } from 'react-router-dom';
-import { ImageGenerationSettings, ImageEngine, OpenAIModel, StabilityModel } from '../../types';
+import { ImageGenerationSettings, ImageEngine, OpenAIModel, StabilityModel, FluxModel } from '../../types';
 
 const Sidebar: React.FC = () => {
   const { signOut, supabase } = useAuth();
@@ -34,8 +34,8 @@ const Sidebar: React.FC = () => {
 
   const handleEngineChange = async (
     type: 'thumbnail' | 'variations' | 'spriteSheet',
-    provider: 'openai' | 'stability',
-    model: OpenAIModel | StabilityModel,
+    provider: 'openai' | 'stability' | 'flux',
+    model: OpenAIModel | StabilityModel | FluxModel,
     quality?: string,
     size?: string,
     style?: string
@@ -95,8 +95,8 @@ const Sidebar: React.FC = () => {
             const [provider, model] = e.target.value.split(':');
             handleEngineChange(
               type,
-              provider as 'openai' | 'stability',
-              model as OpenAIModel | StabilityModel
+              provider as 'openai' | 'stability' | 'flux',
+              model as OpenAIModel | StabilityModel | FluxModel
             );
           }}
           disabled={isLoading}
@@ -109,6 +109,9 @@ const Sidebar: React.FC = () => {
           </optgroup>
           <optgroup label="Stability AI">
             <option value="stability:stable-diffusion-3.5">Stable Diffusion 3.5</option>
+          </optgroup>
+          <optgroup label="Flux">
+            <option value="flux:flux-kontext-pro">Flux Kontext Pro</option>
           </optgroup>
         </select>
 

--- a/src/components/Wizard/steps/StoryStep.tsx
+++ b/src/components/Wizard/steps/StoryStep.tsx
@@ -10,6 +10,7 @@ const StoryStep: React.FC = () => {
     characters,
     storySettings,
     designSettings,
+    generatedPages,
     setStorySettings,
     setGeneratedPages,
     setIsGenerating,
@@ -18,6 +19,16 @@ const StoryStep: React.FC = () => {
   const { storyId } = useParams();
   const [isLoading, setIsLoading] = React.useState(false);
   const [generated, setGenerated] = React.useState<{ title: string; paragraphs: string[] } | null>(null);
+
+  React.useEffect(() => {
+    if (!generated && generatedPages && generatedPages.length > 0) {
+      const paragraphs = generatedPages
+        .filter(p => p.pageNumber > 0)
+        .map(p => p.text);
+      const cover = generatedPages.find(p => p.pageNumber === 0);
+      setGenerated({ title: cover ? cover.text : '', paragraphs });
+    }
+  }, [generatedPages, generated]);
 
   const characterNames = characters.map(c => c.name).join(' y ');
   const suggestions = [

--- a/src/constants/aiProviderCatalog.ts
+++ b/src/constants/aiProviderCatalog.ts
@@ -1,0 +1,77 @@
+export interface AIModelInfo {
+  id: string;
+  description: string;
+  endpoints: {
+    generate?: string;
+    edit?: string;
+    variations?: string;
+    result?: string;
+  };
+}
+
+export interface ProviderInfo {
+  name: 'openai' | 'flux' | 'stability';
+  models: Record<string, AIModelInfo>;
+}
+
+export const aiProviderCatalog: Record<'openai' | 'flux' | 'stability', ProviderInfo> = {
+  openai: {
+    name: 'openai',
+    models: {
+      'gpt-image-1': {
+        id: 'gpt-image-1',
+        description: 'GPT Image 1',
+        endpoints: {
+          generate: 'https://api.openai.com/v1/images/generations',
+          edit: 'https://api.openai.com/v1/images/edits',
+          variations: 'https://api.openai.com/v1/images/variations'
+        }
+      },
+      'dall-e-3': {
+        id: 'dall-e-3',
+        description: 'DALL-E 3',
+        endpoints: {
+          generate: 'https://api.openai.com/v1/images/generations',
+          edit: 'https://api.openai.com/v1/images/edits',
+          variations: 'https://api.openai.com/v1/images/variations'
+        }
+      },
+      'dall-e-2': {
+        id: 'dall-e-2',
+        description: 'DALL-E 2',
+        endpoints: {
+          generate: 'https://api.openai.com/v1/images/generations',
+          edit: 'https://api.openai.com/v1/images/edits',
+          variations: 'https://api.openai.com/v1/images/variations'
+        }
+      }
+    }
+  },
+  flux: {
+    name: 'flux',
+    models: {
+      'flux-kontext-pro': {
+        id: 'flux-kontext-pro',
+        description: 'Flux Kontext Pro',
+        endpoints: {
+          generate: 'https://api.bfl.ai/v1/flux-kontext-pro',
+          edit: 'https://api.bfl.ai/v1/flux-kontext-pro',
+          result: 'https://api.bfl.ai/v1/get_result'
+        }
+      }
+    }
+  },
+  stability: {
+    name: 'stability',
+    models: {
+      'stable-diffusion-3.5': {
+        id: 'stable-diffusion-3.5',
+        description: 'Stable Diffusion 3.5',
+        endpoints: {
+          generate: 'http://localhost:7860/sdapi/v1/txt2img',
+          edit: 'http://localhost:7860/sdapi/v1/img2img'
+        }
+      }
+    }
+  }
+};

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -52,6 +52,7 @@ const INITIAL_STATE: WizardState = {
   meta: {
     title: '',
     synopsis: '',
+    theme: '',
     targetAge: '',
     literaryStyle: '',
     centralMessage: '',
@@ -132,6 +133,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
             ...INITIAL_STATE,
             meta: {
               title: draft.story.title || '',
+              theme: draft.story.theme || '',
               targetAge: draft.story.target_age || '',
               literaryStyle: draft.story.literary_style || '',
               centralMessage: draft.story.central_message || '',
@@ -140,7 +142,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
             },
           });
           setStorySettings({
-            theme: '',
+            theme: draft.story.theme || '',
             targetAge: draft.story.target_age || '',
             literaryStyle: draft.story.literary_style || '',
             centralMessage: draft.story.central_message || '',
@@ -265,6 +267,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
       spreads,
       meta: {
         ...state.meta,
+        theme: storySettings.theme,
         targetAge: storySettings.targetAge,
         literaryStyle: storySettings.literaryStyle,
         centralMessage: storySettings.centralMessage,

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -89,7 +89,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const [generatedPages, setGeneratedPages] = useState<GeneratedPage[]>([]);
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
 
-  useAutosave(state, storyId || null);
+  useAutosave(state, estado, storyId || null);
 
   // Mantener sincronizado el conteo de personajes en el store de flujo
   useEffect(() => {
@@ -120,7 +120,10 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
           if (parsed.designSettings) setDesignSettings(parsed.designSettings);
           if (parsed.characters) setCharacters(parsed.characters);
           if (parsed.generatedPages) setGeneratedPages(parsed.generatedPages);
-          const estadoActual = useWizardFlowStore.getState().estado;
+          if (parsed.flow) {
+            useWizardFlowStore.setState({ estado: parsed.flow });
+          }
+          const estadoActual = parsed.flow || useWizardFlowStore.getState().estado;
           const step = stepFromEstado(estadoActual);
           setCurrentStep(step);
           console.log('[WizardFlow] borrador local cargado', estadoActual);
@@ -148,6 +151,9 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
             centralMessage: draft.story.central_message || '',
             additionalDetails: draft.story.additional_details || '',
           });
+          if (draft.story.wizard_state) {
+            useWizardFlowStore.setState({ estado: draft.story.wizard_state });
+          }
         }
         if (draft.characters) {
           setCharacters(draft.characters);
@@ -171,28 +177,12 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
 
         console.log('[WizardFlow] borrador remoto cargado', useWizardFlowStore.getState().estado);
 
-        let step: WizardStep = 'characters';
-        if (draft.pages && draft.pages.length > 0) step = 'preview';
-        else if (draft.design) step = 'design';
-        else if (draft.story && draft.story.central_message) step = 'story';
-        else if (draft.characters && draft.characters.length > 0) step = 'story';
-        setCurrentStep(step);
-
         if (draft.characters) setPersonajes(draft.characters.length);
-        if (step === 'story') {
-          avanzarEtapa('personajes');
-        } else if (step === 'design') {
-          avanzarEtapa('personajes');
-          avanzarEtapa('cuento');
-        } else if (step === 'preview') {
-          avanzarEtapa('personajes');
-          avanzarEtapa('cuento');
-          avanzarEtapa('diseno');
-        }
-        const nuevoEstado = useWizardFlowStore.getState().estado;
-        const next = stepFromEstado(nuevoEstado);
+
+        const current = draft.story.wizard_state || useWizardFlowStore.getState().estado;
+        const next = stepFromEstado(current);
         setCurrentStep(next);
-        console.log('[WizardFlow] estado tras load', nuevoEstado);
+        console.log('[WizardFlow] estado tras load', current);
       } catch (error) {
         console.error('Error loading draft:', error);
       }
@@ -277,6 +267,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     setState(newState);
     const local = {
       state: newState,
+      flow: estado,
       currentStep,
       storySettings,
       designSettings,

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -77,6 +77,7 @@ export const useAutosave = (state: WizardState, initialStoryId: string | null) =
             id: currentStoryId,
             user_id: user.id,
             title: state.meta.title,
+            theme: state.meta.theme,
             target_age: state.meta.targetAge,
             literary_style: state.meta.literaryStyle,
             central_message: state.meta.centralMessage,

--- a/src/stores/wizardFlowStore.ts
+++ b/src/stores/wizardFlowStore.ts
@@ -27,6 +27,7 @@ interface WizardFlowStore {
   setPersonajes: (count: number) => void;
   avanzarEtapa: (etapa: keyof EstadoFlujo) => void;
   regresarEtapa: (etapa: keyof EstadoFlujo) => void;
+  setEstadoCompleto: (estado: EstadoFlujo) => void;
   resetEstado: () => void;
 }
 
@@ -39,7 +40,7 @@ const initialState: EstadoFlujo = {
 
 export const useWizardFlowStore = create<WizardFlowStore>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       estado: initialState,
       setPersonajes: (count) =>
         set((state) => {
@@ -57,6 +58,11 @@ export const useWizardFlowStore = create<WizardFlowStore>()(
           }
           logEstado(nuevoEstado, 'setPersonajes');
           return { estado: nuevoEstado };
+        }),
+      setEstadoCompleto: (nuevo) =>
+        set(() => {
+          logEstado(nuevo, 'setEstadoCompleto');
+          return { estado: nuevo };
         }),
       avanzarEtapa: (etapa) =>
         set((state) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,8 +31,8 @@ export interface ImageGenerationSettings {
 }
 
 export interface ImageEngine {
-  provider: 'openai' | 'stability';
-  model: OpenAIModel | StabilityModel;
+  provider: 'openai' | 'stability' | 'flux';
+  model: OpenAIModel | StabilityModel | FluxModel;
   quality?: string;
   size?: string;
   style?: string;
@@ -40,6 +40,7 @@ export interface ImageEngine {
 
 export type OpenAIModel = 'dall-e-2' | 'dall-e-3' | 'gpt-image-1';
 export type StabilityModel = 'stable-diffusion-3.5';
+export type FluxModel = 'flux-kontext-pro';
 
 // Tipos para la configuración del cuento
 export interface StorySettings {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,6 +74,7 @@ export interface WizardState {
   meta: {
     title: string;
     synopsis: string;
+    theme: string;
     targetAge: string;
     literaryStyle: string;
     centralMessage: string;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -293,6 +293,7 @@ export type Database = {
           loaders: Json | null
           status: string
           target_age: string | null
+          theme: string | null
           title: string
           updated_at: string | null
           user_id: string
@@ -307,6 +308,7 @@ export type Database = {
           loaders?: Json | null
           status?: string
           target_age?: string | null
+          theme?: string | null
           title: string
           updated_at?: string | null
           user_id: string
@@ -321,6 +323,7 @@ export type Database = {
           loaders?: Json | null
           status?: string
           target_age?: string | null
+          theme?: string | null
           title?: string
           updated_at?: string | null
           user_id?: string

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -291,15 +291,13 @@ export type Database = {
           literary_style: string | null
           loader: Json | null
           loaders: Json | null
-          wizard_state: Json | null
           status: string
           target_age: string | null
-          wizard_state?: Json | null
-          wizard_state?: Json | null
           theme: string | null
           title: string
           updated_at: string | null
           user_id: string
+          wizard_state: Json | null
         }
         Insert: {
           additional_details?: string | null
@@ -315,6 +313,7 @@ export type Database = {
           title: string
           updated_at?: string | null
           user_id: string
+          wizard_state?: Json | null
         }
         Update: {
           additional_details?: string | null
@@ -330,6 +329,7 @@ export type Database = {
           title?: string
           updated_at?: string | null
           user_id?: string
+          wizard_state?: Json | null
         }
         Relationships: []
       }

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -291,8 +291,11 @@ export type Database = {
           literary_style: string | null
           loader: Json | null
           loaders: Json | null
+          wizard_state: Json | null
           status: string
           target_age: string | null
+          wizard_state?: Json | null
+          wizard_state?: Json | null
           theme: string | null
           title: string
           updated_at: string | null

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -284,6 +284,7 @@ export type Database = {
       }
       stories: {
         Row: {
+          theme: string | null
           additional_details: string | null
           central_message: string | null
           created_at: string | null
@@ -299,6 +300,7 @@ export type Database = {
           user_id: string
         }
         Insert: {
+          theme?: string | null
           additional_details?: string | null
           central_message?: string | null
           created_at?: string | null
@@ -314,6 +316,7 @@ export type Database = {
           user_id: string
         }
         Update: {
+          theme?: string | null
           additional_details?: string | null
           central_message?: string | null
           created_at?: string | null

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -284,7 +284,6 @@ export type Database = {
       }
       stories: {
         Row: {
-          theme: string | null
           additional_details: string | null
           central_message: string | null
           created_at: string | null
@@ -300,7 +299,6 @@ export type Database = {
           user_id: string
         }
         Insert: {
-          theme?: string | null
           additional_details?: string | null
           central_message?: string | null
           created_at?: string | null
@@ -316,7 +314,6 @@ export type Database = {
           user_id: string
         }
         Update: {
-          theme?: string | null
           additional_details?: string | null
           central_message?: string | null
           created_at?: string | null

--- a/supabase/functions/analyze-character/index.ts
+++ b/supabase/functions/analyze-character/index.ts
@@ -91,6 +91,7 @@ Deno.serve(async (req)=>{
   let start = 0;
   let promptId: string | undefined;
   let userId: string | null = null;
+  let apiModel = '';
   try {
     const { imageUrl, name, age, description: sanitizedNotes } = await req.json();
     if (!imageUrl) {
@@ -103,7 +104,7 @@ Deno.serve(async (req)=>{
       .single();
     const analysisPrompt = promptRow?.content || '';
     const apiEndpoint = promptRow?.endpoint || 'https://api.openai.com/v1/chat/completions';
-    const apiModel = promptRow?.model || 'gpt-4-turbo';
+    apiModel = promptRow?.model || 'gpt-4-turbo';
     if (promptRow?.id) {
       promptId = promptRow.id;
     }

--- a/supabase/functions/describe-and-sketch/index.ts
+++ b/supabase/functions/describe-and-sketch/index.ts
@@ -66,6 +66,7 @@ Deno.serve(async (req) => {
 
   let promptId: string | undefined;
   let userId: string | null = null;
+  let apiModel = '';
 
   try {
 
@@ -79,7 +80,7 @@ Deno.serve(async (req) => {
       .single();
     const characterPrompt = promptRow?.content || '';
     const apiEndpoint = promptRow?.endpoint || 'https://api.openai.com/v1/images/edits';
-    const apiModel = promptRow?.model || 'gpt-image-1';
+    apiModel = promptRow?.model || 'gpt-image-1';
     promptId = promptRow?.id;
     if (!characterPrompt) throw new Error('Falta el prompt de generación de personaje');
 

--- a/supabase/functions/generate-cover/index.ts
+++ b/supabase/functions/generate-cover/index.ts
@@ -109,6 +109,7 @@ Deno.serve(async (req) => {
 
   let promptId: string | undefined;
   let userId: string | null = null;
+  let apiModel = '';
   const startTime = Date.now();
 
   try {
@@ -165,7 +166,7 @@ Deno.serve(async (req) => {
       
     const basePrompt = promptRow?.content || '';
     const apiEndpoint = promptRow?.endpoint || 'https://api.openai.com/v1/images/generations';
-    const apiModel = promptRow?.model || 'gpt-image-1';
+    apiModel = promptRow?.model || 'gpt-image-1';
     promptId = promptRow?.id;
     if (!basePrompt) throw new Error('No se encontró el prompt');
 

--- a/supabase/functions/generate-thumbnail-variant/index.ts
+++ b/supabase/functions/generate-thumbnail-variant/index.ts
@@ -19,6 +19,7 @@ Deno.serve(async (req) => {
 
   let promptId: string | undefined;
   let userId: string | null = null;
+  let apiModel = '';
 
   try {
     const { imageUrl, promptType } = await req.json();
@@ -34,7 +35,7 @@ Deno.serve(async (req) => {
 
     const stylePrompt = promptRow?.content || '';
     const apiEndpoint = promptRow?.endpoint || 'https://api.openai.com/v1/images/edits';
-    const apiModel = promptRow?.model || 'gpt-image-1';
+    apiModel = promptRow?.model || 'gpt-image-1';
     promptId = promptRow?.id;
     if (!stylePrompt) {
       throw new Error('Prompt not found');

--- a/supabase/migrations/20250626120000_add_theme_column_to_stories.sql
+++ b/supabase/migrations/20250626120000_add_theme_column_to_stories.sql
@@ -1,0 +1,2 @@
+-- Add theme column to stories to store story theme for drafts
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS theme text;

--- a/supabase/migrations/20250626121500_add_wizard_state_column.sql
+++ b/supabase/migrations/20250626121500_add_wizard_state_column.sql
@@ -1,0 +1,2 @@
+-- Store detailed wizard flow per story
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS wizard_state jsonb;


### PR DESCRIPTION
## Summary
- add `theme` column migration for stories
- include theme in Supabase types and wizard state
- persist theme in autosave hook
- restore draft theme in wizard context
- populate story text when pages exist

## Testing
- `npm run lint` *(fails: 46 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_6840a7dfb6ac832ab16cbc4af7be345e