### PR TITLE
Add catalog for AI models

### DIFF
--- a/docs/tech/ai-providers/README.md
+++ b/docs/tech/ai-providers/README.md
@@ -54,6 +54,16 @@ response = client.images.generate(
 - **Generación y Edición**: `https://api.bfl.ai/v1/flux-kontext-pro`
 - **Consulta de Resultados**: `https://api.bfl.ai/v1/get_result`
 
+Estos endpoints están registrados en `src/constants/aiProviderCatalog.ts` para
+facilitar su selección en la interfaz de administración.
+
+<Info>
+  A diferencia de OpenAI, las solicitudes a Flux devuelven un `request_id` y se
+  debe consultar el endpoint de resultados para obtener la imagen una vez lista.
+  Además se utiliza la cabecera `x-key` en lugar de `Authorization`.
+  El código maneja esta comunicación asíncrona dentro de las funciones de Supabase.
+</Info>
+
 ### Modelos Disponibles
 
 #### FLUX.1 Kontext [pro]
@@ -146,6 +156,14 @@ image.save('gato_astronauta.png')
 | Modelo Local           | ❌                       | ❌          | ✅               |
 | Costo                 | Por token                 | Por solicitud| Gratis (autoalojado) |
 | Latencia              | Media-Alta                | Media        | Depende del hardware |
+
+## Resumen de Endpoints y Modelos
+
+| Proveedor | Endpoints | Modelos |
+|-----------|-----------|---------|
+| **OpenAI** | `/v1/images/generations`, `/v1/images/edits`, `/v1/images/variations` | `gpt-image-1`, `dall-e-3`, `dall-e-2` |
+| **Flux** | `/v1/flux-kontext-pro`, `/v1/get_result` | `flux-kontext-pro` |
+| **Stable Diffusion** | `http://localhost:7860` | `stable-diffusion-3.5` |
 
 ## Recomendaciones
 

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -3,7 +3,7 @@ import { BookOpen, User, Settings, LogOut, AlertTriangle, BarChart3, Home } from
 import { useAuth } from '../../context/AuthContext';
 import { useAdmin } from '../../context/AdminContext';
 import { Link } from 'react-router-dom';
-import { ImageGenerationSettings, ImageEngine, OpenAIModel, StabilityModel } from '../../types';
+import { ImageGenerationSettings, ImageEngine, OpenAIModel, StabilityModel, FluxModel } from '../../types';
 
 const Sidebar: React.FC = () => {
   const { signOut, supabase } = useAuth();
@@ -34,8 +34,8 @@ const Sidebar: React.FC = () => {
 
   const handleEngineChange = async (
     type: 'thumbnail' | 'variations' | 'spriteSheet',
-    provider: 'openai' | 'stability',
-    model: OpenAIModel | StabilityModel,
+    provider: 'openai' | 'stability' | 'flux',
+    model: OpenAIModel | StabilityModel | FluxModel,
     quality?: string,
     size?: string,
     style?: string
@@ -95,8 +95,8 @@ const Sidebar: React.FC = () => {
             const [provider, model] = e.target.value.split(':');
             handleEngineChange(
               type,
-              provider as 'openai' | 'stability',
-              model as OpenAIModel | StabilityModel
+              provider as 'openai' | 'stability' | 'flux',
+              model as OpenAIModel | StabilityModel | FluxModel
             );
           }}
           disabled={isLoading}
@@ -109,6 +109,9 @@ const Sidebar: React.FC = () => {
           </optgroup>
           <optgroup label="Stability AI">
             <option value="stability:stable-diffusion-3.5">Stable Diffusion 3.5</option>
+          </optgroup>
+          <optgroup label="Flux">
+            <option value="flux:flux-kontext-pro">Flux Kontext Pro</option>
           </optgroup>
         </select>
 

--- a/src/constants/aiProviderCatalog.ts
+++ b/src/constants/aiProviderCatalog.ts
@@ -1,0 +1,77 @@
+export interface AIModelInfo {
+  id: string;
+  description: string;
+  endpoints: {
+    generate?: string;
+    edit?: string;
+    variations?: string;
+    result?: string;
+  };
+}
+
+export interface ProviderInfo {
+  name: 'openai' | 'flux' | 'stability';
+  models: Record<string, AIModelInfo>;
+}
+
+export const aiProviderCatalog: Record<'openai' | 'flux' | 'stability', ProviderInfo> = {
+  openai: {
+    name: 'openai',
+    models: {
+      'gpt-image-1': {
+        id: 'gpt-image-1',
+        description: 'GPT Image 1',
+        endpoints: {
+          generate: 'https://api.openai.com/v1/images/generations',
+          edit: 'https://api.openai.com/v1/images/edits',
+          variations: 'https://api.openai.com/v1/images/variations'
+        }
+      },
+      'dall-e-3': {
+        id: 'dall-e-3',
+        description: 'DALL-E 3',
+        endpoints: {
+          generate: 'https://api.openai.com/v1/images/generations',
+          edit: 'https://api.openai.com/v1/images/edits',
+          variations: 'https://api.openai.com/v1/images/variations'
+        }
+      },
+      'dall-e-2': {
+        id: 'dall-e-2',
+        description: 'DALL-E 2',
+        endpoints: {
+          generate: 'https://api.openai.com/v1/images/generations',
+          edit: 'https://api.openai.com/v1/images/edits',
+          variations: 'https://api.openai.com/v1/images/variations'
+        }
+      }
+    }
+  },
+  flux: {
+    name: 'flux',
+    models: {
+      'flux-kontext-pro': {
+        id: 'flux-kontext-pro',
+        description: 'Flux Kontext Pro',
+        endpoints: {
+          generate: 'https://api.bfl.ai/v1/flux-kontext-pro',
+          edit: 'https://api.bfl.ai/v1/flux-kontext-pro',
+          result: 'https://api.bfl.ai/v1/get_result'
+        }
+      }
+    }
+  },
+  stability: {
+    name: 'stability',
+    models: {
+      'stable-diffusion-3.5': {
+        id: 'stable-diffusion-3.5',
+        description: 'Stable Diffusion 3.5',
+        endpoints: {
+          generate: 'http://localhost:7860/sdapi/v1/txt2img',
+          edit: 'http://localhost:7860/sdapi/v1/img2img'
+        }
+      }
+    }
+  }
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,8 +31,8 @@ export interface ImageGenerationSettings {
 }
 
 export interface ImageEngine {
-  provider: 'openai' | 'stability';
-  model: OpenAIModel | StabilityModel;
+  provider: 'openai' | 'stability' | 'flux';
+  model: OpenAIModel | StabilityModel | FluxModel;
   quality?: string;
   size?: string;
   style?: string;
@@ -40,6 +40,7 @@ export interface ImageEngine {
 
 export type OpenAIModel = 'dall-e-2' | 'dall-e-3' | 'gpt-image-1';
 export type StabilityModel = 'stable-diffusion-3.5';
+export type FluxModel = 'flux-kontext-pro';
 
 // Tipos para la configuración del cuento
 export interface StorySettings {


### PR DESCRIPTION
## Summary
- centralize endpoints and models in `aiProviderCatalog`
- drop Flux entries from prompt metadata
- allow selecting model then endpoint in prompt editor
- document Flux endpoints and asynchronous flow

## Testing
- `npm run test:e2e` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_b_6840a71e6e6c832ab8ee2fcfab277ea2