### PR TITLE
Improve logging for wizard flow

### DIFF
--- a/.supabase-functions-cache.json
+++ b/.supabase-functions-cache.json
@@ -1,46 +1,46 @@
 {
   "analyze-character": {
     "hash": "81db67f32144ae8383bef12791c250014b3f4a5ddef9015aba0366776dd0a73b",
-    "updatedAt": "2025-06-04T21:30:45.159Z"
+    "updatedAt": "2025-06-05T03:54:40.567Z"
   },
   "delete-test-stories": {
     "hash": "770bd727a8d4f5875d8f41ed76007516ebbdf884d20c081960848a2aeea84cec",
-    "updatedAt": "2025-06-04T21:30:48.585Z"
+    "updatedAt": "2025-06-05T03:54:43.912Z"
   },
   "describe-and-sketch": {
     "hash": "b32a954588115963f63c492d511607c69613fa702b3fb263ca81798517a37967",
-    "updatedAt": "2025-06-04T21:30:52.665Z"
+    "updatedAt": "2025-06-05T03:54:47.673Z"
   },
   "generate-illustration": {
     "hash": "67f5628323dd3e3ba3882567576011634bea6b07368e56b156fdfa5b90e4db1d",
-    "updatedAt": "2025-06-04T21:31:00.644Z"
+    "updatedAt": "2025-06-05T03:54:54.256Z"
   },
   "generate-scene": {
     "hash": "0b712ddf8c3b4dde0552e94000d86ce1310865ebff95fe36ce0b387455b50720",
-    "updatedAt": "2025-06-04T21:31:04.004Z"
+    "updatedAt": "2025-06-05T03:54:57.663Z"
   },
   "generate-spreads": {
     "hash": "7f38ab0f30e4f2bfad0a0a9160d4d90592ae5f30abaf9202a308d41136312ef5",
-    "updatedAt": "2025-06-04T21:31:07.386Z"
+    "updatedAt": "2025-06-05T03:55:01.110Z"
   },
   "generate-thumbnail-variant": {
     "hash": "ebde506ed6fcae6210b86718a31d3065300765736cf07d951894fcc3617d7d96",
-    "updatedAt": "2025-06-04T21:31:14.248Z"
+    "updatedAt": "2025-06-05T03:55:08.867Z"
   },
   "generate-variations": {
     "hash": "20034a2b9244ef1f3871f6c52a3bc9556b930f620ad7ef68e95e3114f96c88f6",
-    "updatedAt": "2025-06-04T21:31:17.543Z"
+    "updatedAt": "2025-06-05T03:55:12.102Z"
   },
   "send-reset-email": {
     "hash": "a0141c2fb36c1f0ab79af42fd7b3187b2d7aea605793cff0f68c98de2ca88e24",
-    "updatedAt": "2025-06-04T21:31:21.671Z"
+    "updatedAt": "2025-06-05T03:55:16.509Z"
   },
   "generate-story": {
     "hash": "317e5b0ab2c84cff9fa392deccd1f2b2ff1136e7fdb9fea6a5b99649773541cc",
-    "updatedAt": "2025-06-04T21:31:10.806Z"
+    "updatedAt": "2025-06-05T03:55:05.450Z"
   },
   "generate-cover": {
     "hash": "3bb018cd8248f1b82aaba516ab9fda73ceea2e53ae606f283c1a5f48509812a6",
-    "updatedAt": "2025-06-04T21:30:57.125Z"
+    "updatedAt": "2025-06-05T03:54:50.907Z"
   }
 }

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -71,6 +71,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     avanzarEtapa,
     regresarEtapa,
     resetEstado,
+    setEstadoCompleto,
   } = useWizardFlowStore();
   const [state, setState] = useState<WizardState>(INITIAL_STATE);
   const [currentStep, setCurrentStep] = useState<WizardStep>('characters');
@@ -121,7 +122,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
           if (parsed.characters) setCharacters(parsed.characters);
           if (parsed.generatedPages) setGeneratedPages(parsed.generatedPages);
           if (parsed.flow) {
-            useWizardFlowStore.setState({ estado: parsed.flow });
+            setEstadoCompleto(parsed.flow);
           }
           const estadoActual = parsed.flow || useWizardFlowStore.getState().estado;
           const step = stepFromEstado(estadoActual);
@@ -152,7 +153,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
             additionalDetails: draft.story.additional_details || '',
           });
           if (draft.story.wizard_state) {
-            useWizardFlowStore.setState({ estado: draft.story.wizard_state });
+            setEstadoCompleto(draft.story.wizard_state);
           }
         }
         if (draft.characters) {

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -80,9 +80,7 @@ export const useAutosave = (
         // Save story metadata
         const { error: storyError } = await supabase
           .from('stories')
-          .upsert({
-            id: currentStoryId,
-            user_id: user.id,
+          .update({
             title: state.meta.title,
             theme: state.meta.theme,
             target_age: state.meta.targetAge,
@@ -93,7 +91,7 @@ export const useAutosave = (
             updated_at: new Date().toISOString(),
             status: 'draft'
           })
-          .select();
+          .eq('id', currentStoryId);
 
         if (storyError) throw storyError;
 

--- a/src/stores/wizardFlowStore.ts
+++ b/src/stores/wizardFlowStore.ts
@@ -14,7 +14,9 @@ export interface EstadoFlujo {
 }
 
 const logEstado = (estado: EstadoFlujo, accion: string) => {
-  console.log(`[WizardFlow] ${accion}`, {
+  const id = localStorage.getItem('current_story_draft_id');
+  const suffix = id ? id.slice(-6) : '------';
+  console.log(`[WizardFlow:${suffix}] ${accion}`, {
     personajes: estado.personajes.estado,
     cuento: estado.cuento,
     diseno: estado.diseno,


### PR DESCRIPTION
## Summary
- add story ID suffix to wizard flow log entries
- update autosave flow to ensure wizard state is persisted
- use `setEstadoCompleto` to load draft flow from storage or remote

## Testing
- `npm run lint` *(fails: 60 problems)*
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_b_68410f73a55c832a9dfe2320d17f105a