### PR TITLE
Improve wizard state persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Added `generate-story` Edge Function for story creation and cover generation.
 - UI now displays generated covers on home.
 - Documentation added at `docs/tech/story-generation.md`.
+- Wizard state now persists in Supabase and localStorage allowing users to resume drafts exactly where they left off. See `docs/flow/wizard-states.md`.

--- a/docs/flow/wizard-states.md
+++ b/docs/flow/wizard-states.md
@@ -34,9 +34,13 @@ export interface EstadoFlujo {
    - No se puede avanzar a una etapa si la anterior no está en estado `completado`.
    - Al asignar los tres personajes se marca automáticamente la etapa de personajes como `completado`.
 2. **Persistencia**
-   - El estado se guarda con `zustand` utilizando `localStorage`, permitiendo reanudar el progreso al volver a la aplicación.
+   - El flujo se mantiene en el store `zustand` y se sincroniza con la columna `wizard_state` de la tabla `stories`.
+   - Cada actualización del cuento envía el estado completo a Supabase.
 3. **Carga de datos**
-   - Al continuar desde el inicio se identifica la primera etapa en `borrador` y se navega a ella cargando la información guardada.
+   - Al montar el wizard se intenta restaurar primero desde `localStorage` (backup o borrador principal).
+   - Si no existe información local se consulta la BD y se aplica el `wizard_state` guardado.
+4. **Solo avance**
+   - Una etapa marcada como `completado` no regresa a `borrador` salvo que el usuario cambie los datos correspondientes.
 
 ## Uso
 
@@ -45,6 +49,8 @@ El store `useWizardFlowStore` expone acciones para actualizar cada etapa y avanz
 ```ts
 const { estado, setPersonajes, avanzarEtapa, regresarEtapa, resetEstado } = useWizardFlowStore();
 ```
+
+Además, el store mantiene `currentStoryId` para identificar el borrador activo y evitar registros de log sin contexto.
 
 Estas acciones pueden integrarse en los componentes del wizard para mantener el seguimiento del flujo de creación.
 

--- a/src/components/Modals/ModalPersonajes.tsx
+++ b/src/components/Modals/ModalPersonajes.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { Plus, X, Loader, Trash2, Edit } from 'lucide-react';
 import { Character } from '../../types';
 import Button from '../UI/Button';
+import { initialFlowState } from '../../stores/wizardFlowStore';
 
 interface ModalPersonajesProps {
   isOpen: boolean;
@@ -105,7 +106,8 @@ const ModalPersonajes: React.FC<ModalPersonajesProps> = ({ isOpen, onClose }) =>
         .insert({
           user_id: user?.id,
           status: 'draft',
-          title: 'Nuevo cuento'
+          title: 'Nuevo cuento',
+          wizard_state: initialFlowState
         })
         .select()
         .single();

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -68,12 +68,17 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
 
   useEffect(() => {
     if (storyId) {
-      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      if (uuidRegex.test(storyId)) {
-        localStorage.setItem('current_story_draft_id', storyId);
-      }
+      setStoryId(storyId);
     }
-  }, [storyId]);
+  }, [storyId, setStoryId]);
+
+  useEffect(() => {
+    return () => {
+      resetEstado();
+      setStoryId(null);
+      localStorage.removeItem('current_story_draft_id');
+    };
+  }, [resetEstado, setStoryId]);
   const {
     estado,
     setPersonajes,
@@ -81,6 +86,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     regresarEtapa,
     resetEstado,
     setEstadoCompleto,
+    setStoryId,
   } = useWizardFlowStore();
   const [state, setState] = useState<WizardState>(INITIAL_STATE);
   const [currentStep, setCurrentStep] = useState<WizardStep>('characters');
@@ -114,73 +120,72 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   };
 
   useEffect(() => {
-    const loadDraft = async () => {
-      if (!storyId || !user) {
-        return;
+    if (!storyId) return;
+
+    useWizardFlowStore.getState().resetEstado();
+
+    const backupKey = `story_draft_${storyId}_backup`;
+    const mainKey = `story_draft_${storyId}`;
+    const localBackup = localStorage.getItem(backupKey);
+    const localDraft = !localBackup ? localStorage.getItem(mainKey) : null;
+
+    if (localBackup || localDraft) {
+      const raw = JSON.parse(localBackup || localDraft!);
+      const { state: localState, flow } = raw;
+      useWizardFlowStore.getState().setEstadoCompleto(flow);
+      setCharacters(localState.characters || []);
+      setStorySettings(localState.meta || INITIAL_STATE.meta);
+      if (localState.designSettings) setDesignSettings(localState.designSettings);
+      if (localState.spreads) {
+        const mapped = localState.spreads.map((p: any) => ({
+          id: p.id,
+          pageNumber: p.pageNumber,
+          text: p.text,
+          imageUrl: p.imageUrl,
+          prompt: p.prompt,
+        }));
+        setGeneratedPages(mapped);
       }
+      const etapaInicial = stepFromEstado(useWizardFlowStore.getState().estado);
+      setCurrentStep(etapaInicial);
+      return;
+    }
 
-      console.log('[WizardFlow] loadDraft inicio');
-      try {
-        const draft = await storyService.getStoryDraft(storyId);
-        if (draft.story) {
-          setState({
-            ...INITIAL_STATE,
-            meta: {
-              title: draft.story.title || '',
-              theme: draft.story.theme || '',
-              targetAge: draft.story.target_age || '',
-              literaryStyle: draft.story.literary_style || '',
-              centralMessage: draft.story.central_message || '',
-              additionalDetails: draft.story.additional_details || '',
-              status: draft.story.status,
-            },
-          });
-          setStorySettings({
-            theme: draft.story.theme || '',
-            targetAge: draft.story.target_age || '',
-            literaryStyle: draft.story.literary_style || '',
-            centralMessage: draft.story.central_message || '',
-            additionalDetails: draft.story.additional_details || '',
-          });
-          if (draft.story.wizard_state) {
-            setEstadoCompleto(draft.story.wizard_state);
-          }
-        }
-        if (draft.characters) {
-          setCharacters(draft.characters);
-        }
-        if (draft.design) {
-          setDesignSettings({
-            visualStyle: draft.design.visual_style,
-            colorPalette: draft.design.color_palette,
-          });
-        }
-        if (draft.pages) {
-          const pages = draft.pages.map(p => ({
-            id: p.id,
-            pageNumber: p.page_number,
-            text: p.text,
-            imageUrl: p.image_url,
-            prompt: p.prompt,
-          }));
-          setGeneratedPages(pages);
-        }
-
-        console.log('[WizardFlow] borrador remoto cargado', useWizardFlowStore.getState().estado);
-
-        if (draft.characters) setPersonajes(draft.characters.length);
-
-        const current = draft.story.wizard_state || useWizardFlowStore.getState().estado;
-        const next = stepFromEstado(current);
-        setCurrentStep(next);
-        console.log('[WizardFlow] estado tras load', current);
-      } catch (error) {
-        console.error('Error loading draft:', error);
+    storyService.getStoryDraft(storyId).then(draft => {
+      const s = draft.story;
+      if (s.wizard_state) {
+        setEstadoCompleto(s.wizard_state);
+      } else {
+        useWizardFlowStore.getState().resetEstado();
       }
-    };
-
-    loadDraft();
-  }, [storyId, user]);
+      if (draft.characters) setCharacters(draft.characters);
+      setStorySettings({
+        theme: s.theme || '',
+        targetAge: s.target_age || '',
+        literaryStyle: s.literary_style || '',
+        centralMessage: s.central_message || '',
+        additionalDetails: s.additional_details || '',
+      });
+      if (draft.design) {
+        setDesignSettings({
+          visualStyle: draft.design.visual_style || '',
+          colorPalette: draft.design.color_palette || '',
+        });
+      }
+      if (draft.pages) {
+        const mapped = draft.pages.map(p => ({
+          id: p.id,
+          pageNumber: p.page_number,
+          text: p.text,
+          imageUrl: p.image_url || '',
+          prompt: p.prompt || ''
+        }));
+        setGeneratedPages(mapped);
+      }
+      const etapaInicial = stepFromEstado(useWizardFlowStore.getState().estado);
+      setCurrentStep(etapaInicial);
+    });
+  }, [storyId]);
 
   const steps: WizardStep[] = ['characters', 'story', 'design', 'preview', 'export'];
   const stepMap: Record<WizardStep, keyof EstadoFlujo | null> = {
@@ -205,10 +210,6 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const prevStep = () => {
     const currentIndex = steps.indexOf(currentStep);
     if (currentIndex > 0) {
-      const etapa = stepMap[currentStep];
-      if (etapa) {
-        regresarEtapa(etapa);
-      }
       setCurrentStep(steps[currentIndex - 1]);
     }
   };

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { WizardState, EstadoFlujo } from '../types';
+import { storyService } from '../services/storyService';
 
 const AUTOSAVE_DELAY = 1000; // 1 second delay between saves
 const MAX_RETRIES = 3;
@@ -78,20 +79,16 @@ export const useAutosave = (
         }
 
         // Save story metadata
-        const { error: storyError } = await supabase
-          .from('stories')
-          .update({
-            title: state.meta.title,
-            theme: state.meta.theme,
-            target_age: state.meta.targetAge,
-            literary_style: state.meta.literaryStyle,
-            central_message: state.meta.centralMessage,
-            additional_details: state.meta.additionalDetails,
-            wizard_state: flow,
-            updated_at: new Date().toISOString(),
-            status: 'draft'
-          })
-          .eq('id', currentStoryId);
+        const { error: storyError } = await storyService.persistStory(currentStoryId, {
+          title: state.meta.title,
+          theme: state.meta.theme,
+          target_age: state.meta.targetAge,
+          literary_style: state.meta.literaryStyle,
+          central_message: state.meta.centralMessage,
+          additional_details: state.meta.additionalDetails,
+          updated_at: new Date().toISOString(),
+          status: 'draft'
+        });
 
         if (storyError) throw storyError;
 
@@ -131,12 +128,6 @@ export const useAutosave = (
     };
   }, [state, flow, supabase, user]);
 
-  // Cleanup storyId on unmount
-  useEffect(() => {
-    return () => {
-      localStorage.removeItem('current_story_draft_id');
-    };
-  }, []);
 
   // Expose recovery method
   const recoverFromBackup = async (id: string) => {

--- a/src/pages/MyStories.tsx
+++ b/src/pages/MyStories.tsx
@@ -6,6 +6,7 @@ import { storyService } from '../services/storyService';
 import { useNavigate } from 'react-router-dom';
 import StoryCard from '../components/StoryCard';
 import { EstadoFlujo } from '../types';
+import { initialFlowState } from '../stores/wizardFlowStore';
 import type { WizardStep } from '../context/WizardContext';
 
 interface Story {
@@ -62,7 +63,12 @@ const MyStories: React.FC = () => {
     try {
       const { data: story, error } = await supabase
         .from('stories')
-        .insert({ user_id: user?.id, status: 'draft', title: 'Nuevo cuento' })
+        .insert({
+          user_id: user?.id,
+          status: 'draft',
+          title: 'Nuevo cuento',
+          wizard_state: initialFlowState
+        })
         .select()
         .single();
 

--- a/src/services/storyService.ts
+++ b/src/services/storyService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '../lib/supabase';
 import { Character } from '../types';
+import { useWizardFlowStore } from '../stores/wizardFlowStore';
 
 /**
  * Deletes a story and optionally its orphan characters using Supabase RPCs.
@@ -38,6 +39,15 @@ export const storyService = {
     const { data, error } = await supabase.rpc('delete_story_preserve_characters', { story_id: storyId });
     if (error) throw error;
     if (data) await cleanupStorage(data as string[]);
+  },
+
+  persistStory(id: string, fields: Partial<import('../types/supabase').Database['public']['Tables']['stories']['Update']>) {
+    const { estado } = useWizardFlowStore.getState();
+    return supabase
+      .from('stories')
+      .update({ ...fields, wizard_state: estado })
+      .eq('id', id)
+      .single();
   },
 
   async generateStory(params: {


### PR DESCRIPTION
## Summary
- keep current story id in wizard flow store
- persist wizard state in Supabase via new `persistStory`
- load wizard drafts from local storage or database
- create stories with initial wizard state
- document updated wizard state flow

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_b_6841f3f60d74832aacfc3303113e2c0e