### PR TITLE
Update admin flow toggles with metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,5 @@
 - Documentation added at `docs/tech/story-generation.md`.
 - Wizard state now persists in Supabase and localStorage allowing users to resume drafts exactly where they left off. See `docs/flow/wizard-states.md`.
 - Fixed a reference error when initializing `setStoryId` inside `WizardContext`.
+- Admin panel now guarda la configuración de cada actividad y muestra métricas de los últimos 10 minutos.
+- Nuevas columnas `actividad` y `edge_function` en `prompt_metrics`.

--- a/docs/components/StageActivityCard.md
+++ b/docs/components/StageActivityCard.md
@@ -1,0 +1,30 @@
+# 🎛️ StageActivityCard
+
+Tarjeta utilizada en el panel de administración para controlar cada actividad del flujo.
+
+## 📋 Descripción
+
+Muestra el nombre de la actividad, la función asociada y un toggle para activarla o desactivarla. Además indica el número de llamadas activas y estadísticas de los últimos 10 minutos.
+
+## 🔧 Props
+
+```typescript
+interface ActivityStats {
+  total: number;
+  errorRate: number;
+  errors: Record<string, number>;
+}
+
+interface Props {
+  label: string;
+  fn: string;
+  enabled: boolean;
+  inflight: number;
+  stats?: ActivityStats;
+  onToggle: (value: boolean) => void;
+}
+```
+
+## 📈 Métricas
+
+El componente recibe `stats` con el total de llamadas registradas en `prompt_metrics` durante los últimos 10 minutos, la tasa de error y un desglose por tipo de error.

--- a/docs/tech/admin-analytics.md
+++ b/docs/tech/admin-analytics.md
@@ -57,15 +57,19 @@ Cada inserción o eliminación en la tabla dispara una recarga de datos.
 
 ## Componente `StageActivityCard`
 
-El componente `StageActivityCard` muestra el estado de cada actividad, con un toggle para activarla o desactivarla y el número de llamadas activas:
+El componente `StageActivityCard` muestra el estado de cada actividad. Indica si está **activada** o **desactivada**, el número de llamadas activas y un resumen de las métricas de los últimos 10 minutos:
 
 ```tsx
 <StageActivityCard
   label="Generar descripción"
   enabled={settings.personajes.generar_descripcion}
   inflight={inflightCount}
+  stats={{ total: 3, errorRate: 0.33, errors: { service_error: 1 } }}
   onToggle={(value) => toggle('personajes', 'generar_descripcion', value)}
 />
+
+La propiedad `stats` se obtiene consultando `prompt_metrics` para los últimos 10 minutos y
+muestra el número total de llamadas, la tasa de errores y el desglose por tipo de error.
 ```
 
 ## Página `/admin/flujo`

--- a/src/components/StageActivityCard.tsx
+++ b/src/components/StageActivityCard.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 
+interface ActivityStats {
+  total: number;
+  errorRate: number;
+  errors: Record<string, number>;
+}
+
 interface Props {
   label: string;
   fn: string;
   enabled: boolean;
   inflight: number;
+  stats?: ActivityStats;
   onToggle: (value: boolean) => void;
 }
 
-const StageActivityCard: React.FC<Props> = ({ label, fn, enabled, inflight, onToggle }) => {
+const StageActivityCard: React.FC<Props> = ({ label, fn, enabled, inflight, stats, onToggle }) => {
   return (
     <div className="rounded-lg bg-white shadow p-4 space-y-3 border border-gray-200">
       <div className="flex items-center justify-between">
@@ -25,7 +32,21 @@ const StageActivityCard: React.FC<Props> = ({ label, fn, enabled, inflight, onTo
           />
         </button>
       </div>
-      <p className="text-xs text-purple-700">Llamadas activas: {inflight}</p>
+      <div className="text-xs space-y-1">
+        <p className="text-purple-700">Llamadas activas: {inflight}</p>
+        <p className="text-gray-700">
+          Estado: <span className={enabled ? 'text-green-600' : 'text-red-600'}>{enabled ? 'Activado' : 'Desactivado'}</span>
+        </p>
+        {stats && (
+          <p className="text-gray-500">
+            Últimos 10m: {stats.total} llamadas, {(stats.errorRate * 100).toFixed(0)}% errores
+            {Object.keys(stats.errors).length > 0 && ' – '}
+            {Object.entries(stats.errors)
+              .map(([type, count]) => `${type}: ${count}`)
+              .join(', ')}
+          </p>
+        )}
+      </div>
     </div>
   );
 };

--- a/supabase/functions/_shared/metrics.ts
+++ b/supabase/functions/_shared/metrics.ts
@@ -17,6 +17,8 @@ export interface PromptMetric {
   tokens_salida?: number;
   usuario_id?: string | null;
   metadatos?: Record<string, unknown> | null;
+  actividad?: string | null;
+  edge_function?: string | null;
 }
 
 export async function getUserId(req: Request): Promise<string | null> {

--- a/supabase/functions/analyze-character/index.ts
+++ b/supabase/functions/analyze-character/index.ts
@@ -177,6 +177,8 @@ Deno.serve(async (req)=>{
       tokens_entrada: responseData.usage?.prompt_tokens ?? 0,
       tokens_salida: responseData.usage?.completion_tokens ?? 0,
       usuario_id: userId,
+      actividad: ACTIVITY,
+      edge_function: FILE,
     });
     console.log(`[${FILE}] [${STAGE}] [OUT] ${JSON.stringify(responseData)}`);
     if (!response.ok) {
@@ -220,6 +222,8 @@ Deno.serve(async (req)=>{
         tokens_salida: 0,
         usuario_id: userId,
         metadatos: { error: (error as Error).message },
+        actividad: ACTIVITY,
+        edge_function: FILE,
       });
     }
     const errResp = handleOpenAIError(error);

--- a/supabase/functions/describe-and-sketch/index.ts
+++ b/supabase/functions/describe-and-sketch/index.ts
@@ -182,6 +182,8 @@ Deno.serve(async (req) => {
       tokens_entrada: tokensEntrada,
       tokens_salida: tokensSalida,
       usuario_id: userId,
+      actividad: ACTIVITY,
+      edge_function: FILE,
     });
     if (!editRes.ok) {
       const msg = editData.error?.message || editRes.statusText;
@@ -213,6 +215,8 @@ Deno.serve(async (req) => {
       tokens_salida: 0,
       usuario_id: userId,
       metadatos: { error: (error as Error).message },
+      actividad: ACTIVITY,
+      edge_function: FILE,
     });
     return new Response(
       JSON.stringify({ error: error.message || 'Error al generar la miniatura' }),

--- a/supabase/functions/generate-cover/index.ts
+++ b/supabase/functions/generate-cover/index.ts
@@ -329,6 +329,8 @@ Deno.serve(async (req) => {
       tokens_entrada: 0,
       tokens_salida: 0,
       usuario_id: userId,
+      actividad: 'generar_portada',
+      edge_function: 'generate-cover',
     });
 
     console.log('✅ Portada generada exitosamente', {
@@ -357,6 +359,8 @@ Deno.serve(async (req) => {
         tokens_salida: 0,
         usuario_id: userId,
         metadatos: { error: (error as Error).message },
+        actividad: 'generar_portada',
+        edge_function: 'generate-cover',
       });
     }
     

--- a/supabase/functions/generate-illustration/index.ts
+++ b/supabase/functions/generate-illustration/index.ts
@@ -81,6 +81,8 @@ Deno.serve(async (req) => {
       tiempo_respuesta_ms: elapsed,
       estado: response.data?.[0]?.url ? 'success' : 'error',
       error_type: response.data?.[0]?.url ? null : 'service_error',
+      actividad: 'generar_ilustracion',
+      edge_function: 'generate-illustration',
     });
 
     if (!response.data || !response.data[0] || !response.data[0].url) {
@@ -100,6 +102,8 @@ Deno.serve(async (req) => {
       estado: 'error',
       error_type: 'service_error',
       metadatos: { error: (error as Error).message },
+      actividad: 'generar_ilustracion',
+      edge_function: 'generate-illustration',
     });
     return new Response(
       JSON.stringify({ error: error.message }),

--- a/supabase/functions/generate-scene/index.ts
+++ b/supabase/functions/generate-scene/index.ts
@@ -77,6 +77,8 @@ Ilustración para libro infantil. Formato panorámico si es spread.`;
       tiempo_respuesta_ms: elapsed,
       estado: response.data?.[0]?.url ? 'success' : 'error',
       error_type: response.data?.[0]?.url ? null : 'service_error',
+      actividad: 'generar_escena',
+      edge_function: 'generate-scene',
     });
 
     return new Response(
@@ -91,6 +93,8 @@ Ilustración para libro infantil. Formato panorámico si es spread.`;
       estado: 'error',
       error_type: 'service_error',
       metadatos: { error: (error as Error).message },
+      actividad: 'generar_escena',
+      edge_function: 'generate-scene',
     });
     return new Response(
       JSON.stringify({ error: error.message }),

--- a/supabase/functions/generate-spreads/index.ts
+++ b/supabase/functions/generate-spreads/index.ts
@@ -39,6 +39,8 @@ Deno.serve(async (req) => {
           tiempo_respuesta_ms: elapsed,
           estado: response.data?.[0]?.url ? 'success' : 'error',
           error_type: response.data?.[0]?.url ? null : 'service_error',
+          actividad: 'generar_spread',
+          edge_function: 'generate-spreads',
         });
         return response.data[0].url;
       })
@@ -55,6 +57,8 @@ Deno.serve(async (req) => {
       estado: 'error',
       error_type: 'service_error',
       metadatos: { error: (error as Error).message },
+      actividad: 'generar_spread',
+      edge_function: 'generate-spreads',
     });
     return new Response(
       JSON.stringify({ error: error.message }),

--- a/supabase/functions/generate-story/index.ts
+++ b/supabase/functions/generate-story/index.ts
@@ -88,6 +88,8 @@ Deno.serve(async (req) => {
         tokens_entrada: 0,
         tokens_salida: 0,
         usuario_id: userId,
+        actividad: 'generar_historia',
+        edge_function: 'generate-story',
       });
       console.error('Respuesta inválida de OpenAI:', rawResponse.slice(0, 100));
       throw new Error('Formato de respuesta de OpenAI inválido');
@@ -102,6 +104,8 @@ Deno.serve(async (req) => {
       tokens_entrada: respData.usage?.prompt_tokens ?? 0,
       tokens_salida: respData.usage?.completion_tokens ?? 0,
       usuario_id: userId,
+      actividad: 'generar_historia',
+      edge_function: 'generate-story',
     });
 
     if (!resp.ok) {
@@ -234,6 +238,8 @@ Deno.serve(async (req) => {
         tokens_entrada: 0,
         tokens_salida: 0,
         usuario_id: userId,
+        actividad: 'generar_portada',
+        edge_function: 'generate-story',
       });
       if (coverRes.data?.[0]?.url) {
         coverUrl = coverRes.data[0].url;
@@ -274,6 +280,8 @@ Deno.serve(async (req) => {
         tokens_salida: 0,
         usuario_id: userId,
         metadatos: { error: (err as Error).message },
+        actividad: 'generar_historia',
+        edge_function: 'generate-story',
       });
     }
     return new Response(

--- a/supabase/functions/generate-thumbnail-variant/index.ts
+++ b/supabase/functions/generate-thumbnail-variant/index.ts
@@ -150,6 +150,8 @@ Deno.serve(async (req) => {
       tokens_entrada: tokensIn,
       tokens_salida: tokensOut,
       usuario_id: userId,
+      actividad: ACTIVITY,
+      edge_function: FILE,
     });
 
     await endInflightCall(userId, ACTIVITY);
@@ -170,6 +172,8 @@ Deno.serve(async (req) => {
       tokens_salida: 0,
       usuario_id: userId,
       metadatos: { error: (error as Error).message },
+      actividad: ACTIVITY,
+      edge_function: FILE,
     });
     return new Response(JSON.stringify({ error: (error as Error).message }), {
       status: 400,

--- a/supabase/functions/generate-variations/index.ts
+++ b/supabase/functions/generate-variations/index.ts
@@ -36,6 +36,8 @@ Deno.serve(async (req) => {
       tiempo_respuesta_ms: elapsed,
       estado: imageResponse.data?.[0]?.url ? 'success' : 'error',
       error_type: imageResponse.data?.[0]?.url ? null : 'service_error',
+      actividad: 'generar_variacion',
+      edge_function: 'generate-variations',
     });
 
     return new Response(
@@ -52,6 +54,8 @@ Deno.serve(async (req) => {
       estado: 'error',
       error_type: 'service_error',
       metadatos: { error: (error as Error).message },
+      actividad: 'generar_variacion',
+      edge_function: 'generate-variations',
     });
     return new Response(
       JSON.stringify({ error: error.message }),

--- a/supabase/migrations/20250626140000_add_activity_edge_function_to_prompt_metrics.sql
+++ b/supabase/migrations/20250626140000_add_activity_edge_function_to_prompt_metrics.sql
@@ -1,0 +1,3 @@
+-- Add activity and edge_function columns to prompt_metrics
+alter table prompt_metrics add column if not exists actividad text;
+alter table prompt_metrics add column if not exists edge_function text;


### PR DESCRIPTION
## Summary
- persist stage toggles using upsert
- show current state and latest metrics in `StageActivityCard`
- fetch prompt stats for the last 10 minutes in Admin Flow
- log `actividad` and `edge_function` in prompt metrics
- document new component behaviour
- add migration for prompt metrics columns

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run test:e2e` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_b_684237f0d1ac832aa485ca9027ec0f86