### PR TITLE
Mejora de métricas en admin/flujo

### DIFF
--- a/.supabase-functions-cache.json
+++ b/.supabase-functions-cache.json
@@ -1,46 +1,46 @@
 {
   "analyze-character": {
     "hash": "e6e8d3a8767126673f874bc56b8554a0d8341015f17914c0e93b083afb7a48a0",
-    "updatedAt": "2025-06-06T01:53:36.988Z"
+    "updatedAt": "2025-06-06T15:39:15.041Z"
   },
   "delete-test-stories": {
     "hash": "770bd727a8d4f5875d8f41ed76007516ebbdf884d20c081960848a2aeea84cec",
-    "updatedAt": "2025-06-06T01:53:41.302Z"
+    "updatedAt": "2025-06-06T15:39:19.692Z"
   },
   "describe-and-sketch": {
-    "hash": "48f2dce4a08777ce4a9d818514ef479082947f8969ebdfbd1b1f69d5c7b573df",
-    "updatedAt": "2025-06-06T01:53:46.231Z"
+    "hash": "541c399f6cbb6c34e25186017a6e42ed41f4e1e23582787b41a08ab7f977dbb5",
+    "updatedAt": "2025-06-06T15:39:23.399Z"
   },
   "generate-illustration": {
-    "hash": "7d0e3175410fcad3f807e5fa37e72de631273b22a35ac4ec789ef709503e4c86",
-    "updatedAt": "2025-06-06T01:53:53.206Z"
+    "hash": "b232105565e6d18bae5b172965ea14a9181fec8ee786e8277be513f2bc98806f",
+    "updatedAt": "2025-06-06T15:39:30.708Z"
   },
   "generate-scene": {
-    "hash": "f4a7f109510d2ccf88de9f44357cba548c26a4a4b2368cf0a7afcb00ff67cd46",
-    "updatedAt": "2025-06-06T01:53:56.524Z"
+    "hash": "e4332da361b04bf225a0a31cb16ceae839434d50882d69a3e3e7ce49daab5270",
+    "updatedAt": "2025-06-06T15:39:35.179Z"
   },
   "generate-spreads": {
-    "hash": "5422ec42460c4be46141bc02f78e8d80e2e1bb775e0fc75afee26aa117472d23",
-    "updatedAt": "2025-06-06T01:54:00.181Z"
+    "hash": "ce4d29de24de95d7d89a5fece09a556c13e96cf543699583686c278fbbc3450d",
+    "updatedAt": "2025-06-06T15:39:38.645Z"
   },
   "generate-thumbnail-variant": {
-    "hash": "fd8dad45eb9742aacdb493aa31773699a12d8ff81128d2df9ad7dc416624f912",
-    "updatedAt": "2025-06-06T01:54:07.092Z"
+    "hash": "70666ee36517c3373ab4c18b1a6b6437951b42dc464ddf1b59688fcf0a0b4a2c",
+    "updatedAt": "2025-06-06T15:39:46.310Z"
   },
   "generate-variations": {
-    "hash": "6d5a87f15933c14413fb1680f74ced34fbddc901ec7022032dc1d2d0320045f9",
-    "updatedAt": "2025-06-06T01:54:10.469Z"
+    "hash": "0bbe90248e24f73eeed190e0e1f654afbcdfffd25cb9a73e9383bfaaa956bb98",
+    "updatedAt": "2025-06-06T15:39:49.980Z"
   },
   "send-reset-email": {
     "hash": "a0141c2fb36c1f0ab79af42fd7b3187b2d7aea605793cff0f68c98de2ca88e24",
-    "updatedAt": "2025-06-06T01:54:16.028Z"
+    "updatedAt": "2025-06-06T15:39:54.607Z"
   },
   "generate-story": {
-    "hash": "2b0d0936ffb97407c4cf2436a286602cd9f5a027bfe303a8ea248d65a28a6b66",
-    "updatedAt": "2025-06-06T01:54:03.766Z"
+    "hash": "7e3a6ed4dfc9b98bbfaa0b323163e0bbd609247b7312cff20c7810ceab301ffa",
+    "updatedAt": "2025-06-06T15:39:42.269Z"
   },
   "generate-cover": {
-    "hash": "0d5c762840c3199e55ca60b5295128e845b68a6235f8ecf4986eff349bd6ac7f",
-    "updatedAt": "2025-06-06T01:53:49.672Z"
+    "hash": "f88e7c959a2109dddcc101af983aa45ef008a1a9fc067da5370555a95859d0a5",
+    "updatedAt": "2025-06-06T15:39:27.065Z"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,5 @@
 - Nuevo helper `generateWithFlux` para conectar con Flux desde las Edge Functions.
 - Todas las funciones de generación de imágenes detectan el uso de Flux y emplean este helper automáticamente.
 - Nuevo helper `generateWithOpenAI` para centralizar las llamadas a la API de imágenes de OpenAI.
+- `generate-story` y `generate-cover` ahora registran llamadas en `inflight_calls` para mostrarse como activas.
+- `StageActivityCard` usa un gráfico de área apilada para visualizar éxitos y errores de la última hora. Ver `docs/components/StageActivityCard.md`.

--- a/docs/components/StageActivityCard.md
+++ b/docs/components/StageActivityCard.md
@@ -4,15 +4,21 @@ Tarjeta utilizada en el panel de administración para controlar cada actividad d
 
 ## 📋 Descripción
 
-Muestra el nombre de la actividad, la función asociada y un toggle para activarla o desactivarla. Además indica el número de llamadas activas y estadísticas de los últimos 10 minutos.
+Muestra el nombre de la actividad, la función asociada y un toggle para activarla o desactivarla. Además indica el número de llamadas activas y un gráfico del rendimiento de la última hora.
 
 ## 🔧 Props
 
 ```typescript
+interface ActivityPoint {
+  time: string;
+  success: number;
+  error: number;
+}
+
 interface ActivityStats {
   total: number;
   errorRate: number;
-  errors: Record<string, number>;
+  timeline: ActivityPoint[];
 }
 
 interface Props {
@@ -27,4 +33,4 @@ interface Props {
 
 ## 📈 Métricas
 
-El componente recibe `stats` con el total de llamadas registradas en `prompt_metrics` durante los últimos 10 minutos, la tasa de error y un desglose por tipo de error.
+`stats` incluye la serie temporal de la última hora con los éxitos y errores por minuto. El componente utiliza `StackedAreaChart` de `recharts` para mostrar esta información.

--- a/docs/tech/admin-analytics.md
+++ b/docs/tech/admin-analytics.md
@@ -57,19 +57,26 @@ Cada inserción o eliminación en la tabla dispara una recarga de datos.
 
 ## Componente `StageActivityCard`
 
-El componente `StageActivityCard` muestra el estado de cada actividad. Indica si está **activada** o **desactivada**, el número de llamadas activas y un resumen de las métricas de los últimos 10 minutos:
+El componente `StageActivityCard` muestra el estado de cada actividad. Indica si está **activada** o **desactivada**, el número de llamadas activas y un gráfico con los éxitos y errores de la última hora:
 
 ```tsx
 <StageActivityCard
   label="Generar descripción"
   enabled={settings.personajes.generar_descripcion}
   inflight={inflightCount}
-  stats={{ total: 3, errorRate: 0.33, errors: { service_error: 1 } }}
+  stats={{
+    total: 42,
+    errorRate: 0.1,
+    timeline: [
+      { time: '12:00', success: 3, error: 1 },
+      { time: '12:01', success: 4, error: 0 },
+      // ...
+    ]
+  }}
   onToggle={(value) => toggle('personajes', 'generar_descripcion', value)}
 />
 
-La propiedad `stats` se obtiene consultando `prompt_metrics` para los últimos 10 minutos y
-muestra el número total de llamadas, la tasa de errores y el desglose por tipo de error.
+La propiedad `stats` se obtiene consultando `prompt_metrics` para la última hora y agrupa las llamadas por minuto en series `success` y `error`.
 ```
 
 ## Página `/admin/flujo`

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dropzone": "^14.2.3",
         "react-router-dom": "^6.22.3",
         "react-use": "^17.5.0",
+        "recharts": "^2.15.3",
         "uuid": "^9.0.1",
         "zod": "^3.22.4",
         "zustand": "^4.5.2"
@@ -1620,6 +1621,69 @@
         "cypress": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -2780,6 +2844,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3081,6 +3154,127 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3118,6 +3312,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3159,6 +3359,16 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.5.0",
@@ -3607,6 +3817,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -3776,6 +3992,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -4548,6 +4773,15 @@
         "css-in-js-utils": "^3.1.0"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5024,7 +5258,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -6140,6 +6373,37 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/react-universal-interface": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
@@ -6197,6 +6461,44 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/request-progress": {
       "version": "3.0.0",
@@ -6994,6 +7296,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -7341,6 +7649,28 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6466,7 +6466,6 @@
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
       "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
-      "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dropzone": "^14.2.3",
     "react-router-dom": "^6.22.3",
     "react-use": "^17.5.0",
+    "recharts": "^2.15.3",
     "uuid": "^9.0.1",
     "zod": "^3.22.4",
     "zustand": "^4.5.2"

--- a/src/components/StageActivityCard.tsx
+++ b/src/components/StageActivityCard.tsx
@@ -1,9 +1,23 @@
 import React from 'react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  Tooltip,
+  YAxis,
+  ResponsiveContainer,
+} from 'recharts';
+
+interface ActivityPoint {
+  time: string;
+  success: number;
+  error: number;
+}
 
 interface ActivityStats {
   total: number;
   errorRate: number;
-  errors: Record<string, number>;
+  timeline: ActivityPoint[];
 }
 
 interface Props {
@@ -33,18 +47,25 @@ const StageActivityCard: React.FC<Props> = ({ label, fn, enabled, inflight, stat
         </button>
       </div>
       <div className="text-xs space-y-1">
-        <p className="text-purple-700">Llamadas activas: {inflight}</p>
+        <div className="inline-block bg-purple-100 text-purple-700 px-2 py-0.5 rounded-md font-medium">
+          Activas: {inflight}
+        </div>
         <p className="text-gray-700">
           Estado: <span className={enabled ? 'text-green-600' : 'text-red-600'}>{enabled ? 'Activado' : 'Desactivado'}</span>
         </p>
         {stats && (
-          <p className="text-gray-500">
-            Últimos 10m: {stats.total} llamadas, {(stats.errorRate * 100).toFixed(0)}% errores
-            {Object.keys(stats.errors).length > 0 && ' – '}
-            {Object.entries(stats.errors)
-              .map(([type, count]) => `${type}: ${count}`)
-              .join(', ')}
-          </p>
+          <div className="h-24">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={stats.timeline} stackOffset="expand">
+                <XAxis dataKey="time" hide />
+                <YAxis hide />
+                <Tooltip formatter={(v: number) => Math.round(v as number)} />
+                <Area type="monotone" dataKey="success" stackId="1" stroke="#16a34a" fill="#bbf7d0" />
+                <Area type="monotone" dataKey="error" stackId="1" stroke="#dc2626" fill="#fecaca" />
+              </AreaChart>
+            </ResponsiveContainer>
+            <p className="text-gray-500 mt-1">Última hora: {stats.total} llamadas, {(stats.errorRate * 100).toFixed(0)}% errores</p>
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- track inflight calls in `generate-story` y `generate-cover`
- agrega area chart y cajas de info en `StageActivityCard`
- muestra métricas de la última hora en el panel de flujo
- actualiza documentación y changelog
- instala `recharts`

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_b_684308f54f48832a9df9c18e9b849b93