### PR TITLE
Implementa default de wizard_state en la creación de cuentos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - UI now displays generated covers on home.
 - Documentation added at `docs/tech/story-generation.md`.
 - Wizard state now persists in Supabase and localStorage allowing users to resume drafts exactly where they left off. See `docs/flow/wizard-states.md`.
+- Nuevo trigger `enforce_wizard_state_trigger` garantiza la integridad del flujo y establece un valor por defecto para `wizard_state` en la tabla `stories`.
+- La creación de historias desde "Nuevo cuento" usa ese valor por defecto y ya no envía `wizard_state` desde el frontend.
 - Fixed a reference error when initializing `setStoryId` inside `WizardContext`.
 - Admin panel now guarda la configuración de cada actividad y muestra métricas de los últimos 10 minutos.
 - Nuevas columnas `actividad` y `edge_function` en `prompt_metrics`.

--- a/docs/flow/user-flow.md
+++ b/docs/flow/user-flow.md
@@ -10,6 +10,7 @@
 
 2. **Nuevo Cuento y Personajes**
    - Usuario presiona **Nuevo cuento** en el dashboard
+   - Se crea un registro en `stories` con el `wizard_state` inicial
    - Se abre el asistente (wizard) y un modal para seleccionar personajes
    - Puede crear personajes desde el modal
    - Selecciona hasta 3 personajes para el cuento

--- a/docs/flow/wizard-states.md
+++ b/docs/flow/wizard-states.md
@@ -42,6 +42,21 @@ export interface EstadoFlujo {
 4. **Solo avance**
    - Una etapa marcada como `completado` no regresa a `borrador` salvo que el usuario cambie los datos correspondientes.
 
+## Persistencia en Supabase
+
+Al crear una historia (al presionar **Nuevo cuento** en el dashboard) el campo `wizard_state` se inicializa con el siguiente JSON por defecto:
+
+```json
+{
+  "1.personajes": { "estado": "no_iniciada", "personajesAsignados": 0 },
+  "2.cuento": "no_iniciada",
+  "3.diseno": "no_iniciada",
+  "4.vistaPrevia": "no_iniciada"
+}
+```
+
+Un trigger `enforce_wizard_state_trigger` valida cada actualización y evita retrocesos o saltos de etapa. Si una transición no es secuencial la operación se cancela.
+
 ## Uso
 
 El store `useWizardFlowStore` expone acciones para actualizar cada etapa y avanzar o retroceder entre ellas.

--- a/src/components/Modals/ModalPersonajes.tsx
+++ b/src/components/Modals/ModalPersonajes.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import { Plus, X, Loader, Trash2, Edit } from 'lucide-react';
 import { Character } from '../../types';
 import Button from '../UI/Button';
-import { initialFlowState } from '../../stores/wizardFlowStore';
 
 interface ModalPersonajesProps {
   isOpen: boolean;
@@ -106,8 +105,7 @@ const ModalPersonajes: React.FC<ModalPersonajesProps> = ({ isOpen, onClose }) =>
         .insert({
           user_id: user?.id,
           status: 'draft',
-          title: 'Nuevo cuento',
-          wizard_state: initialFlowState
+          title: 'Nuevo cuento'
         })
         .select()
         .single();

--- a/src/pages/MyStories.tsx
+++ b/src/pages/MyStories.tsx
@@ -6,7 +6,6 @@ import { storyService } from '../services/storyService';
 import { useNavigate } from 'react-router-dom';
 import StoryCard from '../components/StoryCard';
 import { EstadoFlujo } from '../types';
-import { initialFlowState } from '../stores/wizardFlowStore';
 import type { WizardStep } from '../context/WizardContext';
 
 interface Story {
@@ -66,8 +65,7 @@ const MyStories: React.FC = () => {
         .insert({
           user_id: user?.id,
           status: 'draft',
-          title: 'Nuevo cuento',
-          wizard_state: initialFlowState
+          title: 'Nuevo cuento'
         })
         .select()
         .single();

--- a/supabase/migrations/20250627000000_wizard_state_flow.sql
+++ b/supabase/migrations/20250627000000_wizard_state_flow.sql
@@ -1,0 +1,68 @@
+-- Initialize default wizard state and add validation function
+
+-- Default value for new stories
+ALTER TABLE stories
+  ALTER COLUMN wizard_state SET DEFAULT '{"1.personajes": {"estado": "no_iniciada", "personajesAsignados": 0}, "2.cuento": "no_iniciada", "3.diseno": "no_iniciada", "4.vistaPrevia": "no_iniciada"}'::jsonb;
+
+-- Helper to obtain the order of a state
+CREATE OR REPLACE FUNCTION wizard_state_rank(p_state text)
+RETURNS integer AS $$
+BEGIN
+  CASE p_state
+    WHEN 'no_iniciada' THEN RETURN 0;
+    WHEN 'borrador' THEN RETURN 1;
+    WHEN 'completado' THEN RETURN 2;
+    ELSE RETURN -1;
+  END CASE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Trigger function to enforce sequential flow
+CREATE OR REPLACE FUNCTION enforce_wizard_state()
+RETURNS trigger AS $$
+DECLARE
+  old_p text := COALESCE((OLD.wizard_state->'1.personajes'->>'estado'), 'no_iniciada');
+  new_p text := COALESCE((NEW.wizard_state->'1.personajes'->>'estado'), old_p);
+  old_c text := COALESCE((OLD.wizard_state->>'2.cuento'), 'no_iniciada');
+  new_c text := COALESCE((NEW.wizard_state->>'2.cuento'), old_c);
+  old_d text := COALESCE((OLD.wizard_state->>'3.diseno'), 'no_iniciada');
+  new_d text := COALESCE((NEW.wizard_state->>'3.diseno'), old_d);
+  old_v text := COALESCE((OLD.wizard_state->>'4.vistaPrevia'), 'no_iniciada');
+  new_v text := COALESCE((NEW.wizard_state->>'4.vistaPrevia'), old_v);
+BEGIN
+  -- Prevent state regression
+  IF wizard_state_rank(new_p) < wizard_state_rank(old_p) THEN
+    RAISE EXCEPTION 'Estado de personajes invalido';
+  END IF;
+  IF wizard_state_rank(new_c) < wizard_state_rank(old_c) THEN
+    RAISE EXCEPTION 'Estado de cuento invalido';
+  END IF;
+  IF wizard_state_rank(new_d) < wizard_state_rank(old_d) THEN
+    RAISE EXCEPTION 'Estado de diseño invalido';
+  END IF;
+  IF wizard_state_rank(new_v) < wizard_state_rank(old_v) THEN
+    RAISE EXCEPTION 'Estado de vista previa invalido';
+  END IF;
+
+  -- Sequential dependencies
+  IF wizard_state_rank(new_c) > 0 AND wizard_state_rank(new_p) < 2 THEN
+    RAISE EXCEPTION 'No se puede iniciar cuento sin completar personajes';
+  END IF;
+  IF wizard_state_rank(new_d) > 0 AND wizard_state_rank(new_c) < 2 THEN
+    RAISE EXCEPTION 'No se puede iniciar diseño sin completar cuento';
+  END IF;
+  IF wizard_state_rank(new_v) > 0 AND wizard_state_rank(new_d) < 2 THEN
+    RAISE EXCEPTION 'No se puede iniciar vista previa sin completar diseño';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS enforce_wizard_state_trigger ON stories;
+CREATE TRIGGER enforce_wizard_state_trigger
+BEFORE UPDATE OF wizard_state ON stories
+FOR EACH ROW EXECUTE FUNCTION enforce_wizard_state();
+
+GRANT EXECUTE ON FUNCTION wizard_state_rank(text) TO PUBLIC;
+GRANT EXECUTE ON FUNCTION enforce_wizard_state() TO PUBLIC;


### PR DESCRIPTION
## Summary
- elimina el envío manual de `wizard_state` en la creación de cuentos
- documenta que al pulsar **Nuevo cuento** se genera la historia con el estado inicial
- menciona el cambio en el CHANGELOG

## Testing
- `npm run lint` *(fails: command not found)*
- `npm run test:e2e` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68474c8af5c0832a814c0e2e6bae3018