### PR TITLE
Add edge function badges in admin prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Vista de Prompts muestra badges con las Edge Functions que utilizan cada template y permite filtrarlos por función. Documentado en `docs/components/PromptAccordion.md`.
 - Portada principal desbloquea el paso de Diseño sin esperar las variantes. Los mensajes de `stories.loader` ahora se usan en el `OverlayLoader` mientras se genera la portada.
 - Nueva función `generate-image-pages` para generar o regenerar ilustraciones de páginas y edición en `PreviewStep`. Documentado en `docs/tech/generate-image-pages.md` y `docs/components/PreviewStep.md`.
 - Corregido el parámetro `quality` de OpenAI cambiando `hd` por `high` en las funciones de generación de imágenes.

--- a/docs/components/PromptAccordion.md
+++ b/docs/components/PromptAccordion.md
@@ -1,0 +1,25 @@
+# 📂 PromptAccordion
+
+Acordeón utilizado en la administración para editar cada prompt.
+
+## 📋 Descripción
+
+Muestra el tipo, versión y fecha de modificación del prompt. Al colapsar el acordeón se incluyen badges con los nombres de las Edge Functions que usan dicho prompt.
+
+En la parte superior de la página se muestran todos los badges de funciones y al seleccionar uno se filtran los prompts asociados.
+
+## 🔧 Props
+
+```typescript
+interface PromptAccordionProps {
+  prompt: Prompt;
+  onSave: (content: string, endpoint: string, model: string) => Promise<void> | void;
+}
+```
+
+## 🎨 Estilos
+
+- Badges con fondo lila para identificar las funciones.
+- Diseño responsive y acorde al resto del panel de administración.
+
+Al editar un prompt de imágenes se muestran campos para elegir tamaño y calidad cuando se usa OpenAI, o ancho y alto cuando se usa Flux.

--- a/src/components/Prompts/PromptAccordion.tsx
+++ b/src/components/Prompts/PromptAccordion.tsx
@@ -5,6 +5,7 @@ import { Prompt } from '../../types/prompts';
 import { aiProviderCatalog } from '../../constants/aiProviderCatalog';
 import ModelBadge from '../UI/ModelBadge';
 import { getModelType, isCompatibleModel } from '../../utils/modelHelpers';
+import { promptEdgeMap } from '../../constants/promptEdgeMap';
 
 interface PromptAccordionProps {
   prompt: Prompt;
@@ -32,6 +33,7 @@ const PromptAccordion: React.FC<PromptAccordionProps> = ({ prompt, onSave }) => 
   const [endpoint, setEndpoint] = useState(prompt.endpoint || '');
   const [model, setModel] = useState(prompt.model || 'gpt-4o');
   const [isSaving, setIsSaving] = useState(false);
+  const edgeFunctions = promptEdgeMap[prompt.type] || [];
 
   const modelToProvider: Record<string, string> = React.useMemo(() => {
     const map: Record<string, string> = {};
@@ -88,12 +90,25 @@ const PromptAccordion: React.FC<PromptAccordionProps> = ({ prompt, onSave }) => 
         className="w-full flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100"
       >
 
-        <span className="text-left">
-          <span className="font-bold">{prompt.type}</span>{' '}
-          <span className="text-sm italic font-normal">
-            (v{prompt.version}, modificado {formatRelativeTime(prompt.updated_at)})
+        <span className="text-left flex flex-col gap-1">
+          <span>
+            <span className="font-bold">{prompt.type}</span>{' '}
+            <span className="text-sm italic font-normal">
+              (v{prompt.version}, modificado {formatRelativeTime(prompt.updated_at)})
+            </span>
           </span>
-
+          {edgeFunctions.length > 0 && (
+            <span className="flex flex-wrap gap-1 mt-1">
+              {edgeFunctions.map((e) => (
+                <span
+                  key={e}
+                  className="bg-indigo-100 text-indigo-800 text-xs px-2 py-0.5 rounded"
+                >
+                  {e}
+                </span>
+              ))}
+            </span>
+          )}
         </span>
         <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
       </button>

--- a/src/constants/promptEdgeMap.ts
+++ b/src/constants/promptEdgeMap.ts
@@ -1,0 +1,15 @@
+export const promptEdgeMap: Record<string, string[]> = {
+  PROMPT_DESCRIPCION_PERSONAJE: ['analyze-character'],
+  PROMPT_GENERADOR_CUENTOS: ['generate-story'],
+  PROMPT_CUENTO_PORTADA: ['generate-story', 'generate-cover'],
+  PROMPT_CUENTO_PAGINA: ['generate-image-pages'],
+  PROMPT_CREAR_MINIATURA_PERSONAJE: ['describe-and-sketch'],
+  PROMPT_ESTILO_KAWAII: ['generate-cover-variant', 'generate-thumbnail-variant'],
+  PROMPT_ESTILO_ACUARELADIGITAL: ['generate-cover-variant', 'generate-thumbnail-variant'],
+  PROMPT_ESTILO_BORDADO: ['generate-cover-variant', 'generate-thumbnail-variant'],
+  PROMPT_ESTILO_MANO: ['generate-cover-variant', 'generate-thumbnail-variant'],
+  PROMPT_ESTILO_RECORTES: ['generate-cover-variant', 'generate-thumbnail-variant'],
+  PROMPT_VARIANTE_TRASERA: ['generate-thumbnail-variant'],
+  PROMPT_VARIANTE_LATERAL: ['generate-thumbnail-variant'],
+};
+export const edgeFunctionList = Array.from(new Set(Object.values(promptEdgeMap).flat()));

--- a/src/pages/Admin/Prompts/PromptsManager.tsx
+++ b/src/pages/Admin/Prompts/PromptsManager.tsx
@@ -4,11 +4,17 @@ import PromptForm from '../../../components/Prompts/PromptForm';
 import PromptAccordion from '../../../components/Prompts/PromptAccordion';
 import Button from '../../../components/UI/Button';
 import { useAdmin } from '../../../context/AdminContext';
+import { edgeFunctionList, promptEdgeMap } from '../../../constants/promptEdgeMap';
 
 const PromptsManager: React.FC = () => {
   const isAdmin = useAdmin();
   const { prompts, createPrompt, updatePrompt, loading } = usePrompts();
   const [showForm, setShowForm] = useState(false);
+  const [filterEdge, setFilterEdge] = useState<string | null>(null);
+
+  const filteredPrompts = filterEdge
+    ? prompts.filter(p => (promptEdgeMap[p.type] || []).includes(filterEdge))
+    : prompts;
 
   if (!isAdmin) {
     return <p>No autorizado</p>;
@@ -21,8 +27,27 @@ const PromptsManager: React.FC = () => {
         <Button onClick={() => setShowForm(true)}>Nuevo Prompt</Button>
       </div>
       {loading && <p>Cargando...</p>}
+      <div className="flex flex-wrap gap-2">
+        {edgeFunctionList.map(edge => (
+          <span
+            key={edge}
+            onClick={() => setFilterEdge(edge)}
+            className={`cursor-pointer inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${filterEdge === edge ? 'bg-indigo-600 text-white' : 'bg-indigo-100 text-indigo-800'}`}
+          >
+            {edge}
+          </span>
+        ))}
+        {filterEdge && (
+          <button
+            onClick={() => setFilterEdge(null)}
+            className="text-xs underline text-gray-500"
+          >
+            Mostrar todos
+          </button>
+        )}
+      </div>
       <div className="space-y-2">
-        {prompts.map(p => (
+        {filteredPrompts.map(p => (
           <PromptAccordion
             key={p.id}
             prompt={p}

--- a/src/utils/modelHelpers.ts
+++ b/src/utils/modelHelpers.ts
@@ -27,7 +27,13 @@ export function isCompatibleModel(modelId: string, promptType: string): boolean 
   const modelType = getModelType(modelId);
   
   // Para prompts de imagen, solo permitir modelos de imagen
-  if (promptType === 'PROMPT_CUENTO_PORTADA' || promptType === 'PROMPT_CUENTO_PAGINA') {
+  if (
+    promptType === 'PROMPT_CUENTO_PORTADA' ||
+    promptType === 'PROMPT_CUENTO_PAGINA' ||
+    promptType === 'PROMPT_CREAR_MINIATURA_PERSONAJE' ||
+    promptType.startsWith('PROMPT_ESTILO_') ||
+    promptType.startsWith('PROMPT_VARIANTE_')
+  ) {
     return modelType === 'image';
   }
   


### PR DESCRIPTION
## Summary
- show edge function names on collapsed prompt accordions
- filter prompts by edge function
- document PromptAccordion component
- expand compatible model list for image prompts

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_b_684b4a81140c832aaf8bf5d744f02a22