### PR TITLE
Implementa estilo y referencias en generate-image-pages

### DIFF
--- a/.supabase-functions-cache.json
+++ b/.supabase-functions-cache.json
@@ -1,54 +1,54 @@
 {
   "analyze-character": {
     "hash": "e6e8d3a8767126673f874bc56b8554a0d8341015f17914c0e93b083afb7a48a0",
-    "updatedAt": "2025-06-13T13:42:36.578Z"
+    "updatedAt": "2025-06-13T17:55:52.601Z"
   },
   "delete-test-stories": {
     "hash": "770bd727a8d4f5875d8f41ed76007516ebbdf884d20c081960848a2aeea84cec",
-    "updatedAt": "2025-06-13T13:42:40.010Z"
+    "updatedAt": "2025-06-13T17:55:56.467Z"
   },
   "describe-and-sketch": {
     "hash": "541c399f6cbb6c34e25186017a6e42ed41f4e1e23582787b41a08ab7f977dbb5",
-    "updatedAt": "2025-06-13T13:42:43.493Z"
+    "updatedAt": "2025-06-13T17:55:59.940Z"
   },
   "generate-illustration": {
     "hash": "c74b041e87fa053643b0dd141cb8fadb82034f5e09c2365839da4c96f63a7084",
-    "updatedAt": "2025-06-13T13:42:53.847Z"
+    "updatedAt": "2025-06-13T17:56:09.928Z"
   },
   "generate-scene": {
     "hash": "a4d98b61a2d1f656ef9f00fd1625d0f997b10f09b7153a2a457466bde07c41f7",
-    "updatedAt": "2025-06-13T13:43:00.799Z"
+    "updatedAt": "2025-06-13T17:56:17.080Z"
   },
   "generate-spreads": {
     "hash": "13decde1fce5ca931de5a8cbe25fcb38d7e0c8c64bbabe3d10dcb018ff5512ed",
-    "updatedAt": "2025-06-13T13:43:04.175Z"
+    "updatedAt": "2025-06-13T17:56:20.482Z"
   },
   "generate-thumbnail-variant": {
     "hash": "70666ee36517c3373ab4c18b1a6b6437951b42dc464ddf1b59688fcf0a0b4a2c",
-    "updatedAt": "2025-06-13T13:43:11.287Z"
+    "updatedAt": "2025-06-13T17:56:27.302Z"
   },
   "generate-variations": {
     "hash": "5011c971f43ba4041a8756cc05b0c7e94114f484db598f41f3150ed8b2ed54d8",
-    "updatedAt": "2025-06-13T13:43:14.565Z"
+    "updatedAt": "2025-06-13T17:56:30.588Z"
   },
   "send-reset-email": {
     "hash": "a0141c2fb36c1f0ab79af42fd7b3187b2d7aea605793cff0f68c98de2ca88e24",
-    "updatedAt": "2025-06-13T13:43:18.414Z"
+    "updatedAt": "2025-06-13T17:56:35.865Z"
   },
   "generate-story": {
     "hash": "bb76c5fec9d690101cfc4aef3b74d9570df28375ebdf65c38864d6cba1884981",
-    "updatedAt": "2025-06-13T13:43:07.581Z"
+    "updatedAt": "2025-06-13T17:56:23.920Z"
   },
   "generate-cover": {
     "hash": "1a08221f4f7b89a5996767e287755a55cb526d043a8145c47eab234444818f35",
-    "updatedAt": "2025-06-13T13:42:46.944Z"
+    "updatedAt": "2025-06-13T17:56:03.312Z"
   },
   "generate-cover-variant": {
     "hash": "5cf0006e7570b8d40be4d3281c41211b70e7387527ce9e2b48b53ad2cbb531cf",
-    "updatedAt": "2025-06-13T13:42:50.375Z"
+    "updatedAt": "2025-06-13T17:56:06.679Z"
   },
   "generate-image-pages": {
-    "hash": "0a8878fdc43b52ddebdd38b2489f5d32811395a352a2cc3dee0209889380aadf",
-    "updatedAt": "2025-06-13T13:42:57.319Z"
+    "hash": "5dcc8c5feb638a886d543c1a361311ef529cdbca9fffb4ea9f5eea8d7ac04959",
+    "updatedAt": "2025-06-13T17:56:13.728Z"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Los badges de Edge Function utilizan colores pasteles distintos para cada tipo.
 - Portada principal desbloquea el paso de Diseño sin esperar las variantes. Los mensajes de `stories.loader` ahora se usan en el `OverlayLoader` mientras se genera la portada.
 - Nueva función `generate-image-pages` para generar o regenerar ilustraciones de páginas y edición en `PreviewStep`. Documentado en `docs/tech/generate-image-pages.md` y `docs/components/PreviewStep.md`.
+- `generate-image-pages` ahora aplica automáticamente el estilo seleccionado y las imágenes de referencia de los personajes.
 - Corregido el parámetro `quality` de OpenAI cambiando `hd` por `high` en las funciones de generación de imágenes.
 - Al editar prompts de imagen se pueden ajustar tamaño y calidad (OpenAI) o ancho y alto (Flux).
 - Se corrige `generatePageImage` para incluir `story_id` en la solicitud y asegurar la actualización de imágenes de las páginas.

--- a/docs/tech/generate-image-pages.md
+++ b/docs/tech/generate-image-pages.md
@@ -32,3 +32,11 @@ La función `storyService.generatePageImage(storyId, pageId)` envía esta
 petición incluyendo el identificador de la historia. El `WizardContext` expone
 `generatePageImage(pageId)` para actualizar o crear la imagen de la página
 mostrada en el paso de vista previa.
+
+### Estilos y referencias
+
+El edge function recupera automáticamente el estilo seleccionado en
+`story_designs` y lo combina con el prompt base `PROMPT_CUENTO_PAGINA`.
+También descarga las miniaturas de los personajes de la historia para
+enviarlas como referencias si el endpoint elegido soporta imágenes (por
+ejemplo `images/edits` de OpenAI o el modelo de Flux).

--- a/docs/tech/generate-image-pages.md
+++ b/docs/tech/generate-image-pages.md
@@ -36,7 +36,7 @@ mostrada en el paso de vista previa.
 ### Estilos y referencias
 
 El edge function recupera automáticamente el estilo seleccionado en
-`story_designs` y lo combina con el prompt base `PROMPT_CUENTO_PAGINA`.
+`story_designs` y lo combina con el prompt base `PROMPT_CUENTO_PAGINAS`.
 También descarga las miniaturas de los personajes de la historia para
 enviarlas como referencias si el endpoint elegido soporta imágenes (por
 ejemplo `images/edits` de OpenAI o el modelo de Flux).

--- a/docs/tech/generate-image-pages.md
+++ b/docs/tech/generate-image-pages.md
@@ -11,12 +11,11 @@ Función que genera o regenera la ilustración de una página del cuento.
 ```json
 {
   "story_id": "<uuid>",
-  "page_id": "<uuid>",
-  "prompt": "Escena detallada de la página"
+  "page_id": "<uuid>"
 }
 ```
-
-Todos los campos son obligatorios.
+Todos los campos son obligatorios. El texto de la página y el estilo se obtienen
+automáticamente desde la base de datos.
 
 ## Response
 
@@ -29,7 +28,7 @@ y se actualiza el registro correspondiente en `story_pages.image_url`.
 
 ## Uso desde el frontend
 
-La función `storyService.generatePageImage(storyId, pageId, prompt)` envía esta
+La función `storyService.generatePageImage(storyId, pageId)` envía esta
 petición incluyendo el identificador de la historia. El `WizardContext` expone
-`generatePageImage(pageId, prompt)` para actualizar o crear la imagen de la página
+`generatePageImage(pageId)` para actualizar o crear la imagen de la página
 mostrada en el paso de vista previa.

--- a/src/components/Wizard/WizardNav.tsx
+++ b/src/components/Wizard/WizardNav.tsx
@@ -39,8 +39,7 @@ const WizardNav: React.FC = () => {
         if (page.pageNumber === 0) continue;
         const url = await storyService.generatePageImage(
           storyId,
-          page.id,
-          page.prompt
+          page.id
         );
         setGeneratedPages(prev =>
           prev.map(p => (p.id === page.id ? { ...p, imageUrl: url } : p))

--- a/src/components/Wizard/steps/PreviewStep.tsx
+++ b/src/components/Wizard/steps/PreviewStep.tsx
@@ -37,7 +37,7 @@ const PreviewStep: React.FC = () => {
 
   const handleRegeneratePage = async (pageId: string, prompt: string) => {
     try {
-      await generatePageImage(pageId, prompt);
+      await generatePageImage(pageId);
       createNotification(
         NotificationType.SYSTEM_UPDATE,
         'Imagen actualizada',

--- a/src/constants/promptEdgeMap.ts
+++ b/src/constants/promptEdgeMap.ts
@@ -3,7 +3,7 @@ export const promptEdgeMap: Record<string, string[]> = {
   PROMPT_GENERADOR_CUENTOS: ['generate-story'],
   PROMPT_GENERADOR_PAGINAS: ['generate-image-pages'],
   PROMPT_CUENTO_PORTADA: ['generate-story', 'generate-cover'],
-  PROMPT_CUENTO_PAGINA: ['generate-image-pages'],
+  PROMPT_CUENTO_PAGINAS: ['generate-image-pages'],
   PROMPT_CREAR_MINIATURA_PERSONAJE: ['describe-and-sketch'],
   PROMPT_ESTILO_KAWAII: ['generate-cover-variant', 'generate-thumbnail-variant', 'generate-image-pages'],
   PROMPT_ESTILO_ACUARELADIGITAL: ['generate-cover-variant', 'generate-thumbnail-variant', 'generate-image-pages'],

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -21,7 +21,7 @@ interface WizardContextType {
   setGeneratedPages: (pages: GeneratedPage[]) => void;
   isGenerating: boolean;
   setIsGenerating: (value: boolean) => void;
-  generatePageImage: (pageId: string, prompt: string) => Promise<void>;
+  generatePageImage: (pageId: string) => Promise<void>;
   nextStep: () => void;
   prevStep: () => void;
   canProceed: () => boolean;
@@ -107,13 +107,13 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const [generatedPages, setGeneratedPages] = useState<GeneratedPage[]>([]);
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
 
-  const generatePageImage = async (pageId: string, prompt: string) => {
+  const generatePageImage = async (pageId: string) => {
     if (!storyId) return;
     setIsGenerating(true);
     try {
-      const imageUrl = await storyService.generatePageImage(storyId, pageId, prompt);
+      const imageUrl = await storyService.generatePageImage(storyId, pageId);
       setGeneratedPages(prev => prev.map(p =>
-        p.id === pageId ? { ...p, imageUrl, prompt } : p
+        p.id === pageId ? { ...p, imageUrl } : p
       ));
     } catch (err) {
       console.error('Error regenerating page image:', err);

--- a/src/services/storyService.ts
+++ b/src/services/storyService.ts
@@ -130,7 +130,7 @@ export const storyService = {
     return { story, characters, design, pages };
   },
 
-  async generatePageImage(storyId: string, pageId: string, prompt: string): Promise<string> {
+  async generatePageImage(storyId: string, pageId: string): Promise<string> {
     const { data: { session } } = await supabase.auth.getSession();
     const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY;
     const res = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-image-pages`, {
@@ -139,7 +139,7 @@ export const storyService = {
         Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ story_id: storyId, page_id: pageId, prompt })
+      body: JSON.stringify({ story_id: storyId, page_id: pageId })
     });
     const data = await res.json();
     if (!res.ok) throw new Error(data.error || 'Failed to regenerate page');

--- a/src/utils/modelHelpers.ts
+++ b/src/utils/modelHelpers.ts
@@ -29,7 +29,7 @@ export function isCompatibleModel(modelId: string, promptType: string): boolean 
   // Para prompts de imagen, solo permitir modelos de imagen
   if (
     promptType === 'PROMPT_CUENTO_PORTADA' ||
-    promptType === 'PROMPT_CUENTO_PAGINA' ||
+    promptType === 'PROMPT_CUENTO_PAGINAS' ||
     promptType === 'PROMPT_CREAR_MINIATURA_PERSONAJE' ||
     promptType.startsWith('PROMPT_ESTILO_') ||
     promptType.startsWith('PROMPT_VARIANTE_')

--- a/supabase/functions/generate-image-pages/index.ts
+++ b/supabase/functions/generate-image-pages/index.ts
@@ -2,6 +2,7 @@ import { createClient } from 'npm:@supabase/supabase-js@2.39.7';
 import { generateWithFlux } from '../_shared/flux.ts';
 import { generateWithOpenAI } from '../_shared/openai.ts';
 import { logPromptMetric, getUserId } from '../_shared/metrics.ts';
+import { encode as base64Encode } from 'https://deno.land/std@0.203.0/encoding/base64.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -18,10 +19,58 @@ const FILE = 'generate-image-pages';
 const STAGE = 'historia';
 const ACTIVITY = 'generar_paginas';
 
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 2000; // 2 segundos
+
 async function downloadImage(url: string): Promise<ArrayBuffer> {
   const res = await fetch(url);
   if (!res.ok) throw new Error('Failed to download image');
   return await res.arrayBuffer();
+}
+
+function arrayBufferToBlob(buffer: ArrayBuffer, type: string = 'image/png'): Blob {
+  return new Blob([buffer], { type });
+}
+
+async function generateImageWithRetry(
+  prompt: string,
+  referenceImages: Blob[],
+  endpoint: string,
+  model: string,
+  retries = MAX_RETRIES,
+): Promise<{ url: string }> {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      if (endpoint.includes('bfl.ai')) {
+        let inputUrl: string | undefined;
+        if (referenceImages[0]) {
+          const buf = new Uint8Array(await referenceImages[0].arrayBuffer());
+          const b64 = base64Encode(buf);
+          inputUrl = `data:image/png;base64,${b64}`;
+        }
+        return { url: await generateWithFlux(prompt, inputUrl) };
+      } else if (referenceImages.length === 0) {
+        const payload = { model, prompt, size: '1024x1024', quality: 'high', n: 1 };
+        console.log('[generate-image-pages] [REQUEST]', JSON.stringify(payload));
+        const { url } = await generateWithOpenAI({ endpoint, payload });
+        return { url };
+      } else {
+        const payload = { model, prompt, size: '1024x1024', quality: 'high', n: 1 };
+        console.log('[generate-image-pages] [REQUEST]', JSON.stringify(payload));
+        const { url } = await generateWithOpenAI({
+          endpoint,
+          payload,
+          files: { 'image[]': referenceImages },
+        });
+        return { url };
+      }
+    } catch (error) {
+      if (attempt === retries) throw error;
+      console.log(`Intento ${attempt} fallido, reintentando en ${RETRY_DELAY_MS}ms...`);
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+    }
+  }
+  throw new Error('Número máximo de reintentos alcanzado');
 }
 
 function base64ToBlob(b64: string): Blob {
@@ -44,33 +93,107 @@ Deno.serve(async (req) => {
   const start = Date.now();
 
   try {
-    const { story_id, page_id, prompt } = await req.json();
-    if (!story_id || !page_id || !prompt) {
-      throw new Error('Faltan parámetros');
+    const { story_id, page_id } = await req.json();
+    if (!story_id || !page_id) {
+      throw new Error('Faltan story_id o page_id');
     }
 
     userId = await getUserId(req);
 
-    const { data: promptRow } = await supabaseAdmin
-      .from('prompts')
-      .select('id, endpoint, model')
-      .eq('type', 'PROMPT_CUENTO_PAGINA')
-      .single();
-
-    const endpoint = promptRow?.endpoint || 'https://api.openai.com/v1/images/generations';
-    model = promptRow?.model || 'gpt-image-1';
-    promptId = promptRow?.id;
-
-    const payload = { model, prompt, size: '1024x1024', quality: 'high', n: 1 };
-    console.log('[generate-image-pages] [REQUEST]', JSON.stringify(payload));
-
-    let url: string;
-    if (endpoint.includes('bfl.ai')) {
-      url = await generateWithFlux(prompt);
-    } else {
-      const { url: result } = await generateWithOpenAI({ endpoint, payload });
-      url = result;
+    // Obtener texto y prompt base de la página
+    const { data: pageRow, error: pageError } = await supabaseAdmin
+      .from('story_pages')
+      .select('prompt')
+      .eq('id', page_id)
+      .eq('story_id', story_id)
+      .maybeSingle();
+    if (pageError || !pageRow) {
+      throw new Error('No se encontró la página solicitada');
     }
+
+    const pagePrompt = pageRow.prompt;
+
+    // Obtener estilo y paleta
+    const { data: designRow } = await supabaseAdmin
+      .from('story_designs')
+      .select('visual_style, color_palette')
+      .eq('story_id', story_id)
+      .maybeSingle();
+    const visualStyle = designRow?.visual_style || 'default';
+    const colorPalette = designRow?.color_palette || 'colores pasteles vibrantes';
+
+    // Mapear estilo a tipo de prompt
+    const STYLE_MAP: Record<string, string> = {
+      kawaii: 'PROMPT_ESTILO_KAWAII',
+      acuarela: 'PROMPT_ESTILO_ACUARELADIGITAL',
+      bordado: 'PROMPT_ESTILO_BORDADO',
+      dibujado: 'PROMPT_ESTILO_MANO',
+      recortes: 'PROMPT_ESTILO_RECORTES',
+      default: 'PROMPT_ESTILO_DEFAULT',
+    };
+
+    const stylePromptType = STYLE_MAP[visualStyle] || 'PROMPT_ESTILO_DEFAULT';
+
+    const { data: prompts } = await supabaseAdmin
+      .from('prompts')
+      .select('id, type, content, endpoint, model')
+      .in('type', ['PROMPT_CUENTO_PAGINA', stylePromptType]);
+
+    const pagePromptRow = prompts?.find(p => p.type === 'PROMPT_CUENTO_PAGINA');
+    const stylePromptRow = prompts?.find(p => p.type === stylePromptType);
+
+    const basePrompt = pagePromptRow?.content || '';
+    const stylePrompt = stylePromptRow?.content || '';
+    const endpoint = pagePromptRow?.endpoint || 'https://api.openai.com/v1/images/generations';
+    model = pagePromptRow?.model || 'gpt-image-1';
+    promptId = pagePromptRow?.id;
+
+    const prompt = basePrompt
+      .replace('{estilo}', stylePrompt)
+      .replace('{paleta}', colorPalette || 'colores pasteles vibrantes')
+      .replace('{historia}', pagePrompt);
+
+    // Obtener miniaturas de personajes relacionados
+    const { data: characterRows } = await supabaseAdmin
+      .from('story_characters')
+      .select('characters(thumbnail_url)')
+      .eq('story_id', story_id);
+
+    let referenceImages: Blob[] = [];
+    if (characterRows && characterRows.length > 0) {
+      const urls = characterRows
+        .map((r: any) => r.characters?.thumbnail_url)
+        .filter((u: string | null) => u && typeof u === 'string');
+
+      const downloadPromises = urls.map(async (url: string) => {
+        try {
+          const urlObj = new URL(url);
+          const pathParts = urlObj.pathname.split('/').filter(Boolean);
+          const storageIndex = pathParts.indexOf('storage');
+          if (
+            storageIndex === -1 ||
+            pathParts[storageIndex + 1] !== 'v1' ||
+            pathParts[storageIndex + 2] !== 'object' ||
+            pathParts[storageIndex + 3] !== 'public'
+          ) {
+            throw new Error('Formato de URL no válido');
+          }
+          const bucket = pathParts[storageIndex + 4];
+          const filePath = pathParts.slice(storageIndex + 5).join('/');
+          const { data } = await supabaseAdmin.storage
+            .from(bucket)
+            .download(filePath);
+          return data ?? null;
+        } catch (err) {
+          console.error('No se pudo descargar', err);
+          return null;
+        }
+      });
+      const results = await Promise.all(downloadPromises);
+      referenceImages = results.filter((b): b is Blob => b !== null);
+    }
+
+    const { url } = await generateImageWithRetry(prompt, referenceImages, endpoint, model);
 
     let blob: Blob;
     if (url.startsWith('data:')) {

--- a/supabase/functions/generate-image-pages/index.ts
+++ b/supabase/functions/generate-image-pages/index.ts
@@ -142,9 +142,9 @@ Deno.serve(async (req) => {
     const { data: prompts } = await supabaseAdmin
       .from('prompts')
       .select('id, type, content, endpoint, model')
-      .in('type', ['PROMPT_CUENTO_PAGINA', stylePromptType]);
+      .in('type', ['PROMPT_CUENTO_PAGINAS', stylePromptType]);
 
-    const pagePromptRow = prompts?.find(p => p.type === 'PROMPT_CUENTO_PAGINA');
+    const pagePromptRow = prompts?.find(p => p.type === 'PROMPT_CUENTO_PAGINAS');
     const stylePromptRow = prompts?.find(p => p.type === stylePromptType);
 
     if (!pagePromptRow) {


### PR DESCRIPTION
## Summary
- actualiza `generate-image-pages` para incorporar el estilo de diseño y las miniaturas de personajes
- ajusta el servicio y el contexto del wizard para la nueva API
- documenta el nuevo comportamiento en `generate-image-pages.md`
- agrega nota en el `CHANGELOG`

## Testing
- `npm run lint` *(falla: varios errores de lint)*
- `npm run test:e2e` *(falla: falta Xvfb)*

------
https://chatgpt.com/codex/tasks/task_b_684c5d6a52f0832abe7cb5ce86741a57