### PR TITLE
Implement skipCleanup flag in wizard store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Nueva función `generate-image-pages` para generar o regenerar ilustraciones de páginas y edición en `PreviewStep`. Documentado en `docs/tech/generate-image-pages.md` y `docs/components/PreviewStep.md`.
 - Se agregó registro por consola en autosave y funciones de limpieza para conocer el resultado de las operaciones en Supabase.
 - Los mensajes del flujo del wizard ahora incluyen el `story_id` (últimos seis caracteres) en lugar de `------`.
+- El componente `Wizard` asigna el `storyId` del parámetro de ruta al store para que los registros siempre muestren ese identificador.
 - `generate-image-pages` ahora aplica automáticamente el estilo seleccionado y las imágenes de referencia de los personajes.
 - Corregido el parámetro `quality` de OpenAI cambiando `hd` por `high` en las funciones de generación de imágenes.
 - Al editar prompts de imagen se pueden ajustar tamaño y calidad (OpenAI) o ancho y alto (Flux).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Portada principal desbloquea el paso de Diseño sin esperar las variantes. Los mensajes de `stories.loader` ahora se usan en el `OverlayLoader` mientras se genera la portada.
 - Nueva función `generate-image-pages` para generar o regenerar ilustraciones de páginas y edición en `PreviewStep`. Documentado en `docs/tech/generate-image-pages.md` y `docs/components/PreviewStep.md`.
 - Se agregó registro por consola en autosave y funciones de limpieza para conocer el resultado de las operaciones en Supabase.
+- Los mensajes del flujo del wizard ahora incluyen el `story_id` (últimos seis caracteres) en lugar de `------`.
 - `generate-image-pages` ahora aplica automáticamente el estilo seleccionado y las imágenes de referencia de los personajes.
 - Corregido el parámetro `quality` de OpenAI cambiando `hd` por `high` en las funciones de generación de imágenes.
 - Al editar prompts de imagen se pueden ajustar tamaño y calidad (OpenAI) o ancho y alto (Flux).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 - Vista de Prompts muestra badges con las Edge Functions que utilizan cada template y permite filtrarlos por función. Documentado en `docs/components/PromptAccordion.md`.
+- Eliminada la bandera global `skipWizardCleanup` y reemplazada por `skipCleanup` en el store del wizard. Nuevo flujo documentado en `docs/wizard-flow.md`.
 - Los badges de Edge Function utilizan colores pasteles distintos para cada tipo.
 - Portada principal desbloquea el paso de Diseño sin esperar las variantes. Los mensajes de `stories.loader` ahora se usan en el `OverlayLoader` mientras se genera la portada.
 - Nueva función `generate-image-pages` para generar o regenerar ilustraciones de páginas y edición en `PreviewStep`. Documentado en `docs/tech/generate-image-pages.md` y `docs/components/PreviewStep.md`.
+- Se agregó registro por consola en autosave y funciones de limpieza para conocer el resultado de las operaciones en Supabase.
 - `generate-image-pages` ahora aplica automáticamente el estilo seleccionado y las imágenes de referencia de los personajes.
 - Corregido el parámetro `quality` de OpenAI cambiando `hd` por `high` en las funciones de generación de imágenes.
 - Al editar prompts de imagen se pueden ajustar tamaño y calidad (OpenAI) o ancho y alto (Flux).

--- a/docs/wizard-flow.md
+++ b/docs/wizard-flow.md
@@ -34,6 +34,8 @@ const { skipCleanup, setSkipCleanup } = useWizardFlowStore();
 
 Al navegar para editar un personaje se llama `setSkipCleanup(true)` y al volver se restablece a `false`.
 
+El componente `Wizard` establece el identificador de la historia con `setStoryId(storyId)` usando el parámetro de la ruta. Así los registros en consola siempre incluyen el ID correcto.
+
 ## Registro de operaciones
 
 Las funciones de autosave y limpieza escriben mensajes en la consola para

--- a/docs/wizard-flow.md
+++ b/docs/wizard-flow.md
@@ -1,0 +1,41 @@
+# Flujo del Wizard
+
+Este documento resume cómo se controlan las etapas del asistente de creación de cuentos.
+
+## Estado centralizado
+
+`useWizardFlowStore` define el tipo `EstadoFlujo` para cada etapa del wizard:
+
+```ts
+export interface EstadoFlujo {
+  personajes: { estado: EtapaEstado; personajesAsignados: number };
+  cuento: EtapaEstado;
+  diseno: EtapaEstado;
+  vistaPrevia: EtapaEstado;
+}
+```
+
+Cada etapa puede estar en `no_iniciada`, `borrador` o `completado`. Las transiciones se realizan mediante las acciones del store (`avanzarEtapa`, `regresarEtapa`, `setPersonajes`).
+
+### Reglas principales
+
+1. **Secuencialidad**. No se puede avanzar si la etapa anterior no está marcada como `completado`.
+2. **Auto‑avance**. Al completar una etapa la siguiente pasa automáticamente a `borrador`.
+3. **Persistencia**. El estado se guarda en Supabase y se respalda en `localStorage` utilizando el hook `useAutosave`.
+4. **Edición previa**. Si una etapa anterior se modifica, las siguientes regresan a `borrador`.
+
+## Limpieza controlada
+
+El store incluye la bandera `skipCleanup` para indicar si debe omitirse la eliminación automática del borrador al salir del wizard. Se usa cuando el usuario edita un personaje fuera del asistente.
+
+```ts
+const { skipCleanup, setSkipCleanup } = useWizardFlowStore();
+```
+
+Al navegar para editar un personaje se llama `setSkipCleanup(true)` y al volver se restablece a `false`.
+
+## Registro de operaciones
+
+Las funciones de autosave y limpieza escriben mensajes en la consola para
+informar cuándo se envían datos a Supabase y si la operación fue exitosa
+o produjo un error. Esto facilita depurar problemas de sincronización.

--- a/docs/wizard-flow.md
+++ b/docs/wizard-flow.md
@@ -38,4 +38,6 @@ Al navegar para editar un personaje se llama `setSkipCleanup(true)` y al volver 
 
 Las funciones de autosave y limpieza escriben mensajes en la consola para
 informar cuándo se envían datos a Supabase y si la operación fue exitosa
-o produjo un error. Esto facilita depurar problemas de sincronización.
+o produjo un error. En cada mensaje se muestra el identificador de la
+historia (los últimos seis caracteres) para distinguir fácilmente qué
+borrador está en uso. Esto facilita depurar problemas de sincronización.

--- a/src/components/Wizard/Wizard.tsx
+++ b/src/components/Wizard/Wizard.tsx
@@ -16,7 +16,13 @@ const Wizard: React.FC = () => {
   const { storyId } = useParams();
   const navigate = useNavigate();
   const { supabase } = useAuth();
-  const { skipCleanup, setSkipCleanup } = useWizardFlowStore();
+  const { skipCleanup, setSkipCleanup, setStoryId } = useWizardFlowStore();
+
+  useEffect(() => {
+    if (storyId) {
+      setStoryId(storyId);
+    }
+  }, [storyId, setStoryId]);
 
   useEffect(() => {
     setSkipCleanup(false);

--- a/src/components/Wizard/Wizard.tsx
+++ b/src/components/Wizard/Wizard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useWizard } from '../../context/WizardContext';
 import { useAuth } from '../../context/AuthContext';
+import { useWizardFlowStore } from '../../stores/wizardFlowStore';
 import CharactersStep from './steps/CharactersStep';
 import StoryStep from './steps/StoryStep';
 import DesignStep from './steps/DesignStep';
@@ -15,10 +16,11 @@ const Wizard: React.FC = () => {
   const { storyId } = useParams();
   const navigate = useNavigate();
   const { supabase } = useAuth();
+  const { skipCleanup, setSkipCleanup } = useWizardFlowStore();
 
   useEffect(() => {
-    sessionStorage.removeItem('skipWizardCleanup');
-  }, []);
+    setSkipCleanup(false);
+  }, [setSkipCleanup]);
 
   useEffect(() => {
     if (!storyId) {
@@ -30,30 +32,50 @@ const Wizard: React.FC = () => {
     return () => {
       const cleanup = async () => {
         if (!storyId) return;
-        const skip = sessionStorage.getItem('skipWizardCleanup');
-        sessionStorage.removeItem('skipWizardCleanup');
-        if (skip === 'true') return;
-        const { data } = await supabase
+        if (skipCleanup) {
+          setSkipCleanup(false);
+          return;
+        }
+        const { data, error } = await supabase
           .from('story_characters')
           .select('character_id')
           .eq('story_id', storyId);
+        if (error) {
+          console.error('[Wizard] cleanup select error:', error);
+          return;
+        }
+        console.log('[Wizard] cleanup characters found:', data?.length || 0);
         if (!data || data.length === 0) {
-          await supabase.rpc('delete_full_story', { story_id: storyId });
+          const { error: delError } = await supabase.rpc('delete_full_story', { story_id: storyId });
+          if (delError) {
+            console.error('[Wizard] delete_full_story error:', delError);
+          } else {
+            console.log('[Wizard] delete_full_story success');
+          }
         }
       };
       cleanup();
     };
-  }, [storyId, supabase]);
+  }, [storyId, supabase, skipCleanup, setSkipCleanup]);
 
   useEffect(() => {
     const handleBeforeUnload = async () => {
       if (!storyId) return;
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from('story_characters')
         .select('character_id')
         .eq('story_id', storyId);
+      if (error) {
+        console.error('[Wizard] beforeunload select error:', error);
+        return;
+      }
       if (!data || data.length === 0) {
-        await supabase.rpc('delete_full_story', { story_id: storyId });
+        const { error: delError } = await supabase.rpc('delete_full_story', { story_id: storyId });
+        if (delError) {
+          console.error('[Wizard] beforeunload delete error:', delError);
+        } else {
+          console.log('[Wizard] beforeunload delete success');
+        }
       }
     };
 

--- a/src/components/Wizard/steps/CharactersStep.tsx
+++ b/src/components/Wizard/steps/CharactersStep.tsx
@@ -5,6 +5,7 @@ import { Plus } from 'lucide-react';
 import { useAuth } from '../../../context/AuthContext';
 import { useWizard } from '../../../context/WizardContext';
 import { useCharacterStore } from '../../../stores/characterStore';
+import { useWizardFlowStore } from '../../../stores/wizardFlowStore';
 import CharacterCard from '../../Character/CharacterCard';
 import CharacterSelectionModal from '../../Modal/CharacterSelectionModal';
 
@@ -13,6 +14,7 @@ const CharactersStep: React.FC = () => {
   const { storyId } = useParams();
   const navigate = useNavigate();
   const { characters, setCharacters } = useWizard();
+  const { setSkipCleanup } = useWizardFlowStore();
   const { setCharacters: setStoreCharacters } = useCharacterStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -69,7 +71,7 @@ const CharactersStep: React.FC = () => {
   };
 
   const handleEdit = (id: string) => {
-    sessionStorage.setItem('skipWizardCleanup', 'true');
+    setSkipCleanup(true);
     navigate(`/nuevo-cuento/personaje/${id}/editar`);
   };
 

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -73,8 +73,11 @@ export const useAutosave = (
               .from('characters')
               .upsert(characterData)
               .eq('id', character.id);
-
-            if (characterError) throw characterError;
+            if (characterError) {
+              console.error('[useAutosave] upsert character error:', characterError);
+              throw characterError;
+            }
+            console.log('[useAutosave] character saved:', character.id);
           }
         }
 
@@ -89,8 +92,11 @@ export const useAutosave = (
           updated_at: new Date().toISOString(),
           status: 'draft'
         });
-
-        if (storyError) throw storyError;
+        if (storyError) {
+          console.error('[useAutosave] persistStory error:', storyError);
+          throw storyError;
+        }
+        console.log('[useAutosave] story persisted:', currentStoryId);
 
         // Reset retry count on successful save
         retryCountRef.current = 0;

--- a/src/services/storyService.ts
+++ b/src/services/storyService.ts
@@ -41,13 +41,23 @@ export const storyService = {
     if (data) await cleanupStorage(data as string[]);
   },
 
-  persistStory(id: string, fields: Partial<import('../types/supabase').Database['public']['Tables']['stories']['Update']>) {
+  async persistStory(
+    id: string,
+    fields: Partial<import('../types/supabase').Database['public']['Tables']['stories']['Update']>
+  ) {
     const { estado } = useWizardFlowStore.getState();
-    return supabase
+    console.log('[storyService] persistStory ->', id);
+    const result = await supabase
       .from('stories')
       .update({ ...fields, wizard_state: estado })
       .eq('id', id)
       .single();
+    if (result.error) {
+      console.error('[storyService] persistStory error:', result.error);
+    } else {
+      console.log('[storyService] persistStory success');
+    }
+    return result;
   },
 
   async generateStory(params: {

--- a/src/stores/wizardFlowStore.ts
+++ b/src/stores/wizardFlowStore.ts
@@ -31,6 +31,8 @@ interface WizardFlowStore {
   regresarEtapa: (etapa: keyof EstadoFlujo) => void;
   setEstadoCompleto: (estado: EstadoFlujo) => void;
   resetEstado: () => void;
+  skipCleanup: boolean;
+  setSkipCleanup: (value: boolean) => void;
 }
 
 export const initialFlowState: EstadoFlujo = {
@@ -44,6 +46,7 @@ export const useWizardFlowStore = create<WizardFlowStore>()(
   (set, get) => ({
       currentStoryId: null,
       estado: initialFlowState,
+      skipCleanup: false,
       setStoryId: (id) => {
         set({ currentStoryId: id });
       },
@@ -111,7 +114,8 @@ export const useWizardFlowStore = create<WizardFlowStore>()(
       resetEstado: () => {
         logEstado(initialFlowState, 'resetEstado', get().currentStoryId);
         set({ estado: initialFlowState });
-      }
+      },
+      setSkipCleanup: (value) => set({ skipCleanup: value })
     })
 );
 

--- a/src/stores/wizardFlowStore.ts
+++ b/src/stores/wizardFlowStore.ts
@@ -13,7 +13,7 @@ export interface EstadoFlujo {
 }
 
 const logEstado = (estado: EstadoFlujo, accion: string, id?: string | null) => {
-  const suffix = id?.slice(-6) || '------';
+  const suffix = id ? id.slice(-6) : 'no-id';
   console.log(`[WizardFlow:${suffix}] ${accion}`, {
     personajes: estado.personajes.estado,
     cuento: estado.cuento,


### PR DESCRIPTION
## Summary
- document the wizard flow and transitions
- replace session flag for character edition with `skipCleanup` in the wizard store
- add console logs for database updates and cleanup actions

## Testing
- `npm run lint` *(fails: 45 errors, 17 warnings)*
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_b_684db680ca24832a9ad2cf0108798455