### PR TITLE
fix: Configure Cypress to run only complete_story_flow test

### DIFF
--- a/.github/workflows/verificacion_funcionamiento_core.yml
+++ b/.github/workflows/verificacion_funcionamiento_core.yml
@@ -40,6 +40,7 @@ jobs:
           record: false
           command-timeout: 10000
           default-command-timeout: 10000
+          spec: cypress/e2e/complete_story_flow.cy.js
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Testing
 - `npm run cypress:open` - Open Cypress GUI for interactive testing
-- `npm run cypress:run` - Run all Cypress tests in headless mode
+- `npm run cypress:run` - Run all Cypress tests in headless mode (26 tests)
 - `npm run test:e2e` - Run end-to-end tests (alias for cypress:run)
+- `npm run test:complete-flow` - Run ONLY the complete story flow test (recommended)
 - `npx cypress run --spec "cypress/e2e/flows/3_creacion_personaje.cy.js"` - Run specific test
 
 ### Supabase


### PR DESCRIPTION
## Summary
Comprehensive fix for issue #189 - prevents Cypress from executing all 26 tests when only the complete story flow test is needed.

## Problem Analysis
- **CI/CD**: GitHub workflow was executing all 26 tests instead of just `complete_story_flow.cy.js`
- **Local**: Users were confused about which command to use for single test execution

## Root Cause
1. **Workflow missing spec parameter**: `cypress-io/github-action@v5` without `spec` runs all tests
2. **Documentation unclear**: Didn't highlight the specific command for single test execution

## Complete Solution

### 1. CI/CD Fix (.github/workflows/verificacion_funcionamiento_core.yml)
```yaml
- name: === PRUEBAS DE CONTROL ===
  uses: cypress-io/github-action@v5
  with:
    # ... existing config ...
    spec: cypress/e2e/complete_story_flow.cy.js  # ← Added this line
```

### 2. Documentation Enhancement (CLAUDE.md)
- Clarified that `cypress:run` executes all 26 tests
- Highlighted `npm run test:complete-flow` as recommended for single test
- Added clear distinction between commands

## Verification
✅ **Local**: `npm run test:complete-flow` executes 1 test  
✅ **CI/CD**: Workflow now configured to execute 1 test  
✅ **Documentation**: Commands clearly explained  

## Impact
- **Performance**: CI runs faster (1 test vs 26 tests)
- **Clarity**: Developers know exactly which command to use
- **Consistency**: Local and CI behavior now aligned

Fixes #189

🤖 Generated with [Claude Code](https://claude.ai/code)