### PR TITLE
fix: Eliminar degradado oscuro predeterminado y error de triggers

### DIFF
--- a/src/pages/Admin/StyleEditor/components/EffectsPanel.tsx
+++ b/src/pages/Admin/StyleEditor/components/EffectsPanel.tsx
@@ -15,35 +15,8 @@ const BACKGROUND_PRESETS = [
   { name: 'Negro 50%', value: 'rgba(0,0,0,0.5)' },
 ];
 
-const GRADIENT_PRESETS = [
-  { 
-    name: 'Oscuro inferior', 
-    value: 'linear-gradient(to top, rgba(0,0,0,0.8), rgba(0,0,0,0.4), transparent)' 
-  },
-  { 
-    name: 'Oscuro superior', 
-    value: 'linear-gradient(to bottom, rgba(0,0,0,0.8), rgba(0,0,0,0.4), transparent)' 
-  },
-  { 
-    name: 'Claro inferior', 
-    value: 'linear-gradient(to top, rgba(255,255,255,0.95), rgba(255,255,255,0.7), transparent)' 
-  },
-  { 
-    name: 'Oscuro completo', 
-    value: 'linear-gradient(to top, rgba(0,0,0,0.9), rgba(0,0,0,0.7))' 
-  },
-  { 
-    name: 'Viñeta', 
-    value: 'radial-gradient(ellipse at center, transparent 0%, rgba(0,0,0,0.4) 100%)' 
-  },
-  { 
-    name: 'Sin gradiente', 
-    value: '' 
-  }
-];
 
 const EffectsPanel: React.FC<EffectsPanelProps> = ({ containerStyle, onChange }) => {
-  const [backgroundType, setBackgroundType] = useState<'solid' | 'gradient'>('solid');
 
   // Parsear valores actuales
   const getCurrentBackgroundColor = () => {
@@ -54,9 +27,6 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({ containerStyle, onChange })
     return containerStyle.background || 'rgba(255,255,255,0.9)';
   };
 
-  const getCurrentGradient = () => {
-    return containerStyle.gradientOverlay || '';
-  };
 
   // Extraer valores de box-shadow
   const parseBoxShadow = (shadow: string) => {
@@ -110,45 +80,13 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({ containerStyle, onChange })
 
   return (
     <div className="space-y-6">
-      {/* Tipo de Fondo */}
+      {/* Fondo del Contenedor */}
       <div>
         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
           <Layers className="w-4 h-4 inline mr-1" />
-          Tipo de Fondo
+          Color de Fondo
         </label>
-        <div className="flex gap-2 mb-3">
-          <button
-            onClick={() => setBackgroundType('solid')}
-            className={`flex-1 px-3 py-2 rounded-lg border-2 transition-colors ${
-              backgroundType === 'solid'
-                ? 'border-purple-600 bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300'
-                : 'border-gray-300 dark:border-gray-600 hover:border-gray-400'
-            }`}
-          >
-            <Square className="w-4 h-4 inline mr-1" />
-            Sólido
-          </button>
-          <button
-            onClick={() => setBackgroundType('gradient')}
-            className={`flex-1 px-3 py-2 rounded-lg border-2 transition-colors ${
-              backgroundType === 'gradient'
-                ? 'border-purple-600 bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300'
-                : 'border-gray-300 dark:border-gray-600 hover:border-gray-400'
-            }`}
-          >
-            <Palette className="w-4 h-4 inline mr-1" />
-            Degradado
-          </button>
-        </div>
-      </div>
-
-      {/* Fondo del Contenedor */}
-      {backgroundType === 'solid' && (
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Color de Fondo
-          </label>
-          <div className="space-y-2">
+        <div className="space-y-2">
             {BACKGROUND_PRESETS.map(preset => (
               <button
                 key={preset.value}
@@ -183,31 +121,6 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({ containerStyle, onChange })
             </div>
           </div>
         </div>
-      )}
-
-      {/* Overlay de Gradiente */}
-      {backgroundType === 'gradient' && (
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Overlay de Gradiente
-          </label>
-          <div className="space-y-2">
-            {GRADIENT_PRESETS.map(preset => (
-              <button
-                key={preset.name}
-                onClick={() => onChange({ gradientOverlay: preset.value })}
-                className={`w-full px-3 py-2 text-left rounded-lg border transition-colors ${
-                  containerStyle.gradientOverlay === preset.value
-                    ? 'border-purple-600 bg-purple-50 dark:bg-purple-900/30'
-                    : 'border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
-                }`}
-              >
-                <span className="text-sm">{preset.name}</span>
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
 
       {/* Blur de Fondo */}
       <div>

--- a/src/pages/Admin/StyleEditor/components/StylePreview.tsx
+++ b/src/pages/Admin/StyleEditor/components/StylePreview.tsx
@@ -109,15 +109,8 @@ const StylePreview: React.FC<StylePreviewProps> = ({
 
   const positionStyles = getContainerPosition();
 
-  // Aplicar overlay de gradiente si está configurado
-  const overlayStyle = pageType === 'page' && currentConfig.containerStyle.gradientOverlay
-    ? {
-        background: currentConfig.containerStyle.gradientOverlay,
-        position: 'absolute' as const,
-        inset: 0,
-        pointerEvents: 'none' as const
-      }
-    : null;
+  // Sin overlay de gradiente
+  const overlayStyle = null;
 
   return (
     <div className="relative bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden">

--- a/src/pages/Admin/StyleEditor/components/TemplatesModal.tsx
+++ b/src/pages/Admin/StyleEditor/components/TemplatesModal.tsx
@@ -81,7 +81,7 @@ const TemplatesModal: React.FC<TemplatesModalProps> = ({ onClose, onSelect }) =>
           <div 
             className="absolute bottom-0 left-0 right-0 p-2"
             style={{
-              background: pageStyle.containerStyle.background || pageStyle.containerStyle.gradientOverlay,
+              background: pageStyle.containerStyle.background,
               minHeight: '40%'
             }}
           >

--- a/src/pages/StoryReader.tsx
+++ b/src/pages/StoryReader.tsx
@@ -165,10 +165,6 @@ const StoryReader: React.FC = () => {
                   <div 
                     style={{
                       ...containerStyles,
-                      ...(styleConfig && currentPageIndex > 0 && styleConfig.pageConfig.text.containerStyle.gradientOverlay
-                        ? { background: styleConfig.pageConfig.text.containerStyle.gradientOverlay }
-                        : {}
-                      ),
                       maxWidth: containerStyles.maxWidth || '100%',
                       width: '100%',
                       display: 'flex',

--- a/src/services/styleConfigService.ts
+++ b/src/services/styleConfigService.ts
@@ -189,26 +189,15 @@ class StyleConfigService {
     try {
       console.log('Activating style with ID:', id);
       
-      // Primero desactivar todos los estilos
-      const { error: deactivateError } = await supabase
-        .from('story_style_configs')
-        .update({ is_active: false })
-        .neq('id', id);
+      // Usar una sola query que maneje la lógica de activación
+      // Esto evita conflictos con los triggers
+      const { error } = await supabase.rpc('activate_style_config', {
+        style_id: id
+      });
 
-      if (deactivateError) {
-        console.error('Error deactivating other styles:', deactivateError);
-        throw deactivateError;
-      }
-
-      // Luego activar el estilo seleccionado
-      const { error: activateError } = await supabase
-        .from('story_style_configs')
-        .update({ is_active: true })
-        .eq('id', id);
-
-      if (activateError) {
-        console.error('Error activating style:', activateError);
-        throw activateError;
+      if (error) {
+        console.error('Error activating style:', error);
+        throw error;
       }
 
       console.log('Style activated successfully');

--- a/src/types/styleConfig.ts
+++ b/src/types/styleConfig.ts
@@ -22,7 +22,6 @@ export interface ContainerStyle {
   border?: string;
   boxShadow?: string;
   backdropFilter?: string;
-  gradientOverlay?: string;
 }
 
 export interface TitleConfig {
@@ -128,8 +127,7 @@ export const DEFAULT_PAGE_CONFIG: PageConfig = {
     containerStyle: {
       background: 'transparent',
       padding: '1rem 2rem 6rem 2rem',
-      minHeight: '25%',
-      gradientOverlay: 'linear-gradient(to top, rgba(0,0,0,0.7), rgba(0,0,0,0.5), transparent)'
+      minHeight: '25%'
     }
   }
 };

--- a/supabase/migrations/20250620190000_create_activate_style_function.sql
+++ b/supabase/migrations/20250620190000_create_activate_style_function.sql
@@ -1,0 +1,17 @@
+-- Crear función RPC para activar estilo sin conflictos de triggers
+CREATE OR REPLACE FUNCTION activate_style_config(style_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  -- Desactivar todos los estilos en una sola operación
+  UPDATE story_style_configs 
+  SET is_active = CASE 
+    WHEN id = style_id THEN true 
+    ELSE false 
+  END;
+  
+  -- Verificar que la operación fue exitosa
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Style with ID % not found', style_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- Eliminar degradado oscuro automático en páginas interiores
- Solucionar error de triggers en activación de estilos
- Simplificar UI del panel de efectos

## Problemas Solucionados
1. ✅ **Degradado no configurado**: Páginas interiores tenían automáticamente un degradado oscuro sin haberlo configurado
2. ✅ **Error 27000**: "tuple to be updated was already modified" al aplicar estilos
3. ✅ **UI confusa**: Sección de gradientes en EffectsPanel que no funcionaba correctamente

## Cambios Técnicos
- **DEFAULT_PAGE_CONFIG**: Removido `gradientOverlay` de configuración predeterminada
- **StoryReader**: Eliminada aplicación manual de gradiente no configurado
- **ContainerStyle**: Limpiada interfaz TypeScript removiendo `gradientOverlay`
- **EffectsPanel**: Simplificado para solo manejar colores sólidos de fondo
- **RPC Function**: Nueva función `activate_style_config` para activación sin conflictos
- **styleConfigService**: Usa función RPC en lugar de queries separadas

## Migración Incluida
- `20250620190000_create_activate_style_function.sql` - Función SQL optimizada

## Test Plan
- [ ] Verificar que páginas interiores aparecen sin degradado por defecto
- [ ] Aplicar estilos sin error de triggers
- [ ] Confirmar que solo colores sólidos están disponibles en EffectsPanel
- [ ] Validar que activación de estilos funciona correctamente

## Impact
- **UX mejorada**: Sin elementos visuales no configurados
- **Estabilidad**: Sin errores de base de datos en activación
- **UI más clara**: Panel de efectos simplificado y funcional

🤖 Generated with [Claude Code](https://claude.ai/code)