### PR TITLE
hotfix: Corregir función activate_template para RLS

### DIFF
--- a/supabase/migrations/20250620215000_fix_activate_template_function.sql
+++ b/supabase/migrations/20250620215000_fix_activate_template_function.sql
@@ -1,0 +1,28 @@
+-- Hotfix: Corregir función activate_template para RLS
+-- El problema es que RLS requiere condiciones WHERE explícitas
+
+-- Recrear función activate_template con condiciones WHERE explícitas
+CREATE OR REPLACE FUNCTION activate_template(template_id UUID)
+RETURNS boolean AS $$
+BEGIN
+  -- Desactivar todos los templates (con WHERE explícito para RLS)
+  UPDATE story_style_templates 
+  SET is_active = false 
+  WHERE is_active = true;
+  
+  -- Activar el template especificado
+  UPDATE story_style_templates 
+  SET is_active = true 
+  WHERE id = template_id;
+  
+  -- Verificar que se activó correctamente
+  IF FOUND THEN
+    RETURN true;
+  ELSE
+    RETURN false;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Comentario explicativo del fix
+COMMENT ON FUNCTION activate_template(UUID) IS 'Activa un template específico y desactiva todos los demás. Fixed para RLS con WHERE explícito.';


### PR DESCRIPTION
## 🚨 Hotfix Crítico

Corrige el error `UPDATE requires a WHERE clause` que aparece al intentar activar templates.

## 🐛 Problema
Error al activar templates:
```
code: "21000"
message: "UPDATE requires a WHERE clause"
```

## 🔧 Causa Root
RLS (Row Level Security) en PostgreSQL requiere condiciones WHERE explícitas en los UPDATE statements.

## ✅ Solución
Cambio en la función `activate_template()`:

**ANTES:**
```sql
UPDATE story_style_templates SET is_active = false;
```

**DESPUÉS:**
```sql
UPDATE story_style_templates 
SET is_active = false 
WHERE is_active = true;
```

## 🎯 Resultado
- ✅ Función `activate_template()` funciona correctamente
- ✅ Compatible con políticas RLS
- ✅ Mantiene funcionalidad completa

## ⚡ Urgencia
**ALTA** - Bloquea funcionalidad principal de templates activos

🤖 Generated with [Claude Code](https://claude.ai/code)