### PR TITLE
hotfix: Corregir error crítico de scope pageConfig no definido

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Optimizaciones Story Export (2025-06-21)
+- **Query Optimization**: Optimizada consulta de páginas en `story-export/index.ts` líneas 215-220
+  - Cambio de `select('*')` a `select('id, page_number, text, image_url')` para mejor rendimiento
+  - Agregado campo de desempate `order('id')` para orden consistente de páginas
+  - Implementada validación robusta de datos de páginas con filtering automático
+  - Mejorado logging para debugging de páginas inválidas
+  - Documentación actualizada en `/docs/tech/story-export.md`
+
 ## 2025-01-20 - Implementación completa de size/quality dinámico en edge functions
 - **8 Edge Functions actualizadas**: Implementación estandarizada de configuración dinámica de size/quality
   - **Patrón A (BD + fallback)**: generate-cover, generate-story, generate-thumbnail-variant, generate-cover-variant

--- a/supabase/functions/story-export/index.ts
+++ b/supabase/functions/story-export/index.ts
@@ -547,21 +547,24 @@ function generateHTMLContent(
   // Generar CSS dinámico basado en aspect ratio
   const dynamicCSS = generateDynamicPageCSS(aspectRatio);
   
+  // Definir configuraciones fuera del scope para uso global
+  const coverConfig = styleConfig?.coverConfig?.title || {};
+  const pageConfig = styleConfig?.pageConfig?.text || {};
+  
+  if (styleConfig) {
+    console.log('[story-export] 🎨 Configuración de estilos detectada:');
+    console.log(`[story-export] 📝 pageConfig.fontSize: ${pageConfig.fontSize}`);
+    console.log(`[story-export] 📐 pageConfig.position: ${pageConfig.position}`);
+    console.log(`[story-export] 🎨 pageConfig.containerStyle.background: ${pageConfig.containerStyle?.background}`);
+    console.log(`[story-export] 📏 pageConfig.containerStyle.padding: ${pageConfig.containerStyle?.padding}`);
+  }
+
   // Generar estilos dinámicos desde la configuración (misma estructura que /read)
   const generateDynamicStyles = () => {
     if (!styleConfig) {
       console.log('[story-export] ⚠️ No styleConfig encontrado, usando estilos por defecto');
       return '';
     }
-    
-    const coverConfig = styleConfig.coverConfig?.title || {};
-    const pageConfig = styleConfig.pageConfig?.text || {};
-    
-    console.log('[story-export] 🎨 Configuración de estilos detectada:');
-    console.log(`[story-export] 📝 pageConfig.fontSize: ${pageConfig.fontSize}`);
-    console.log(`[story-export] 📐 pageConfig.position: ${pageConfig.position}`);
-    console.log(`[story-export] 🎨 pageConfig.containerStyle.background: ${pageConfig.containerStyle?.background}`);
-    console.log(`[story-export] 📏 pageConfig.containerStyle.padding: ${pageConfig.containerStyle?.padding}`);
     
     return `
       /* Estilos dinámicos de portada */


### PR DESCRIPTION
## 🚨 Error Crítico en Producción



## 🔍 Causa del Error

**Problema de scope de variables:**
-  estaba definido dentro de  
- Se usaba en CSS de impresión fuera del scope
- Línea 603:  causaba ReferenceError

## 🔧 Solución Implementada

### Antes (❌ Error):


### Después (✅ Corregido):


## 📋 Cambios Realizados

- ✅ Mover  y  a scope global
- ✅ Mantener logging de configuración detectada
- ✅ Eliminar definición local duplicada
- ✅ Acceso consistente en todo generateHTMLContent

## 🧪 Testing

**Error reproducido:** ReferenceError en línea 603
**Solución verificada:** Variables disponibles en scope correcto

## 🎯 Resultado

- ✅ PDF se genera sin errores de referencia
- ✅ CSS dinámico funciona correctamente
- ✅ CSS de impresión accede a configuración
- ✅ Logging mantiene visibilidad de configuración

---

**Prioridad:** 🔥 **CRÍTICA** - Bloquea generación de PDF
**Impacto:** Producción - usuarios no pueden generar PDF

🤖 Generated with [Claude Code](https://claude.ai/code)