### PR TITLE
fix: Corregir edición de prompts en vista previa y parpadeo de imágenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fix: Error al Editar Prompts en Vista Previa (2025-06-22)
+- **Issue reportado**: Error "Faltan story_id o page_id" y parpadeo de imagen al editar prompts
+  - **storyService.ts**: Añadido soporte para prompt personalizado en `generatePageImage`
+  - **WizardContext.tsx**: Actualizada firma de función para aceptar prompt opcional
+  - **PreviewStep.tsx**: Eliminado timestamp dinámico que causaba parpadeo de imagen
+  - **Resultado**: Edición de prompts funciona correctamente para todas las páginas
+  - **Documentación**: `/docs/solutions/fix-preview-prompt-edit/README.md`
+
 ### Fix: Navigation 404 Errors (2025-06-21)
 - **Issue #213 - Navigation 404 Errors**: Resueltos errores 404 intermitentes causados por patrones de navegación mixtos
   - **NotificationCenter.tsx**: Reemplazados `window.location.href` con `useNavigate()` para navegación consistente

--- a/docs/solutions/fix-preview-prompt-edit/README.md
+++ b/docs/solutions/fix-preview-prompt-edit/README.md
@@ -1,0 +1,77 @@
+# Solución: Error al Editar Prompts en Vista Previa
+
+## Problema
+
+Al editar prompts de páginas (no portada) en la etapa de vista previa, ocurrían dos problemas:
+
+1. **Error en Edge Function**: `Error: Faltan story_id o page_id` al hacer click en regenerar
+2. **Parpadeo de imagen**: La imagen pestañeaba al escribir cada carácter en el editor de prompt
+
+## Causa Raíz
+
+1. **Error de Edge Function**: La función `generatePageImage` no soportaba prompts personalizados, a diferencia de `generateCoverImage` que sí actualizaba el prompt en la base de datos antes de regenerar
+2. **Parpadeo**: El componente `<img>` usaba `Date.now()` en el `key` y añadía timestamp al `src`, causando re-renderizado completo al escribir
+
+## Solución Implementada
+
+### 1. Actualización de `storyService.ts`
+```typescript
+async generatePageImage(storyId: string, pageId: string, customPrompt?: string): Promise<string> {
+  // Si se proporciona prompt personalizado, actualizarlo primero en DB
+  if (customPrompt) {
+    const { error } = await supabase
+      .from('story_pages')
+      .update({ prompt: customPrompt })
+      .eq('id', pageId)
+      .eq('story_id', storyId);
+    
+    if (error) {
+      throw new Error('Error al actualizar el prompt de la página');
+    }
+  }
+  // Continuar con la generación...
+}
+```
+
+### 2. Actualización de `WizardContext.tsx`
+```typescript
+const generatePageImage = async (pageId: string, customPrompt?: string) => {
+  // Ahora acepta prompt personalizado
+  const imageUrl = await storyService.generatePageImage(storyId, pageId, customPrompt);
+  // Actualizar estado local incluyendo el nuevo prompt
+}
+```
+
+### 3. Actualización de `PreviewStep.tsx`
+```typescript
+// Pasar promptText al regenerar páginas normales
+await generatePageImage(pageId, promptText);
+
+// Eliminar timestamp dinámico del elemento img
+<img
+  key={`${currentPageData.id}-${currentPageData.imageUrl}`}
+  src={currentPageData.imageUrl || '/placeholder-image.png'}
+  // Sin ?t=${Date.now()}
+/>
+```
+
+## Archivos Modificados
+
+- `src/services/storyService.ts`: Añadir soporte para prompt personalizado
+- `src/context/WizardContext.tsx`: Actualizar firma de función y manejo de estado
+- `src/components/Wizard/steps/PreviewStep.tsx`: Pasar prompt y eliminar timestamp
+
+## Beneficios
+
+1. **Consistencia**: Ahora tanto páginas normales como portadas funcionan igual al editar prompts
+2. **UX mejorada**: Sin parpadeo al escribir en el editor
+3. **Robustez**: El prompt se actualiza en DB antes de regenerar, evitando desincronización
+
+## Testing
+
+Para verificar la solución:
+1. Ir a vista previa de un cuento
+2. Click en "Editar prompt de esta página"
+3. Modificar el prompt y hacer click en "Regenerar"
+4. Verificar que no hay parpadeo al escribir
+5. Verificar que la imagen se regenera con el nuevo prompt

--- a/src/components/Wizard/steps/PreviewStep.tsx
+++ b/src/components/Wizard/steps/PreviewStep.tsx
@@ -52,7 +52,7 @@ const PreviewStep: React.FC = () => {
       if (isCover) {
         await generateCoverImage(promptText);
       } else {
-        await generatePageImage(pageId);
+        await generatePageImage(pageId, promptText);
       }
       createNotification(
         NotificationType.SYSTEM_UPDATE,
@@ -212,8 +212,8 @@ const PreviewStep: React.FC = () => {
               )}
               
               <img
-                key={`${currentPageData.id}-${currentPageData.imageUrl}-${Date.now()}`}
-                src={currentPageData.imageUrl ? `${currentPageData.imageUrl}?t=${Date.now()}` : '/placeholder-image.png'}
+                key={`${currentPageData.id}-${currentPageData.imageUrl}`}
+                src={currentPageData.imageUrl || '/placeholder-image.png'}
                 alt={`Página ${currentPage + 1}`}
                 className="w-full h-full object-cover"
                 onError={(e) => {

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -144,13 +144,13 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const [completionResult, setCompletionResult] = useState<import('../types').CompletionResult | null>(null);
   const [isPdfOutdated, setIsPdfOutdated] = useState<boolean>(false);
 
-  const generatePageImage = async (pageId: string) => {
+  const generatePageImage = async (pageId: string, customPrompt?: string) => {
     if (!storyId) return;
     setIsGenerating(true);
     try {
-      const imageUrl = await storyService.generatePageImage(storyId, pageId);
+      const imageUrl = await storyService.generatePageImage(storyId, pageId, customPrompt);
       setGeneratedPages(prev => prev.map(p =>
-        p.id === pageId ? { ...p, imageUrl } : p
+        p.id === pageId ? { ...p, imageUrl, ...(customPrompt ? { prompt: customPrompt } : {}) } : p
       ));
       // Mark PDF as outdated since page has changed
       if (completionResult?.success) {

--- a/src/services/storyService.ts
+++ b/src/services/storyService.ts
@@ -143,9 +143,23 @@ export const storyService = {
     return { story, characters, design, pages };
   },
 
-  async generatePageImage(storyId: string, pageId: string): Promise<string> {
+  async generatePageImage(storyId: string, pageId: string, customPrompt?: string): Promise<string> {
     const { data: { session } } = await supabase.auth.getSession();
     const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY;
+    
+    // If custom prompt is provided, update the page prompt first
+    if (customPrompt) {
+      const { error } = await supabase
+        .from('story_pages')
+        .update({ prompt: customPrompt })
+        .eq('id', pageId)
+        .eq('story_id', storyId);
+      
+      if (error) {
+        throw new Error('Error al actualizar el prompt de la página');
+      }
+    }
+    
     const res = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/generate-image-pages`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Resumen
- Corrige el error "Faltan story_id o page_id" al editar prompts de páginas en vista previa
- Elimina el parpadeo molesto de imágenes al escribir en el editor de prompts
- Implementa soporte para prompts personalizados en páginas regulares (no solo portadas)

## Problema
1. Al hacer click en "Editar prompt de esta página" y luego regenerar, aparecía error en la edge function
2. La imagen pestañeaba cada vez que se escribía un carácter en el editor

## Solución
- Actualizar `generatePageImage` para aceptar y procesar prompts personalizados
- Actualizar el prompt en la base de datos antes de regenerar la imagen
- Eliminar timestamps dinámicos del componente de imagen que causaban re-renderizado

## Archivos modificados
- `src/services/storyService.ts`: Añadir soporte para prompt personalizado
- `src/context/WizardContext.tsx`: Actualizar firma de función
- `src/components/Wizard/steps/PreviewStep.tsx`: Pasar prompt y eliminar timestamp

## Plan de pruebas
- [x] Navegar a vista previa de un cuento
- [x] Editar prompt de página normal (no portada)
- [x] Verificar que no hay parpadeo al escribir
- [x] Verificar que la imagen se regenera correctamente
- [x] Probar también con la portada para asegurar que sigue funcionando

🤖 Generated with [Claude Code](https://claude.ai/code)