### PR TITLE
fix: AdvancedEditModal preserva tab activo y corrige manejo de portada

### DIFF
--- a/src/components/Wizard/steps/components/AdvancedEditModal.tsx
+++ b/src/components/Wizard/steps/components/AdvancedEditModal.tsx
@@ -100,6 +100,10 @@ const AdvancedEditModal: React.FC<AdvancedEditModalProps> = ({
       // Now regenerate with the new prompt
       await onRegenerate(localPrompt);
       
+      // After regeneration, reset hasChanges to false since everything is in sync
+      // This ensures the UI reflects the current state accurately
+      setHasChanges(false);
+      
       // Don't close modal - user can see the new image in preview
       // Modal will update automatically when parent updates pageData
     } catch (error) {

--- a/src/components/Wizard/steps/components/AdvancedEditModal.tsx
+++ b/src/components/Wizard/steps/components/AdvancedEditModal.tsx
@@ -19,9 +19,12 @@ const AdvancedEditModal: React.FC<AdvancedEditModalProps> = ({
   const [isImageLoading, setIsImageLoading] = useState(false);
   const [lastImageUrl, setLastImageUrl] = useState('');
 
-  // Reset all state when modal opens (first time)
+  // Initialize state when modal first opens
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Reset all state when modal opens (first time only)
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && !isInitialized) {
       setLocalText(pageData.text);
       setLocalPrompt(pageData.prompt);
       setHasChanges(false);
@@ -29,12 +32,16 @@ const AdvancedEditModal: React.FC<AdvancedEditModalProps> = ({
       setShowPreview(false);
       setLastImageUrl(pageData.imageUrl);
       setIsImageLoading(false);
+      setIsInitialized(true);
+    } else if (!isOpen) {
+      // Reset initialization flag when modal closes
+      setIsInitialized(false);
     }
-  }, [isOpen]); // Only depend on isOpen, not pageData
+  }, [isOpen, isInitialized, pageData.text, pageData.prompt, pageData.imageUrl]);
 
   // Update local state when pageData changes during active session (preserve activeTab)
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && isInitialized) {
       setLocalText(pageData.text);
       setLocalPrompt(pageData.prompt);
       setHasChanges(false);
@@ -42,7 +49,7 @@ const AdvancedEditModal: React.FC<AdvancedEditModalProps> = ({
       setLastImageUrl(pageData.imageUrl);
       setIsImageLoading(false);
     }
-  }, [pageData]); // Only depend on pageData changes
+  }, [isOpen, isInitialized, pageData.text, pageData.prompt, pageData.imageUrl]);
 
   // Detect when image URL changes (new image generated)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Corrige reset de tab a "Texto" durante regeneración de imagen en modal avanzado
- Soluciona error `pageId: undefined` al editar prompt de portada en producción
- Implementa lógica de preservación de estado UX durante actualizaciones del modal

## Test plan
- [x] Verificar preservación de tab "Prompt de imagen" durante regeneración
- [x] Probar edición de prompt en portada sin errores de pageId
- [x] Confirmar funcionamiento normal en páginas regulares
- [x] Validar que no hay regresiones en funcionalidad existente

🤖 Generated with [Claude Code](https://claude.ai/code)