### PR TITLE
Fix: Aplicar misma solución de mapeo personaje-imagen a generate-cover

### DIFF
--- a/docs/solutions/character-image-mapping/EXTENSION-COVER.md
+++ b/docs/solutions/character-image-mapping/EXTENSION-COVER.md
@@ -1,0 +1,65 @@
+# Extensión de Solución: generate-cover
+
+## Contexto
+Después de implementar la solución para `generate-image-pages`, se identificó que `generate-cover` tenía el mismo problema de asignación de imágenes de referencia a personajes.
+
+## Problema en generate-cover
+- **storyService.ts** obtiene URLs de thumbnails de personajes y las envía como `reference_image_ids`
+- **generate-cover** recibe estas URLs pero no los nombres de los personajes
+- Sin nombres, no puede hacer asociación explícita imagen-personaje en el prompt
+
+## Solución Implementada
+
+### 1. Nueva función especializada
+```typescript
+async function generateCoverWithCharacters(
+  basePrompt: string,
+  characters: CharacterWithImage[],
+  endpoint: string,
+  model: string,
+  size: string,
+  quality: string,
+): Promise<{ url: string }>
+```
+
+### 2. Obtención mejorada de personajes
+Cambió de recibir `reference_image_ids` a obtener directamente de la base de datos:
+```typescript
+const { data: characterRows } = await supabaseAdmin
+  .from('story_characters')
+  .select('characters(name, thumbnail_url)')
+  .eq('story_id', story_id);
+```
+
+### 3. Prompt enriquecido para portadas
+```typescript
+const enrichedPrompt = `CONTEXTO DE PERSONAJES PRINCIPALES: ${characterDescriptions}. 
+
+PORTADA A GENERAR: ${basePrompt}
+
+IMPORTANTE: Si la portada incluye personajes, usa sus imágenes de referencia correspondientes para mantener consistencia visual. Las imágenes están ordenadas alfabéticamente por nombre de personaje.`;
+```
+
+## Diferencias con generate-image-pages
+- **Propósito**: Portadas generalmente incluyen personajes de forma más estilizada
+- **Texto del prompt**: Adaptado para contexto de portada vs. escena narrativa
+- **Uso opcional**: Los personajes en portadas son opcionales, no siempre necesarios
+
+## Beneficios
+1. **Consistencia visual**: Personajes en portada coinciden con el resto del cuento
+2. **Mejor experiencia**: Portadas más coherentes con los personajes creados
+3. **Flexibilidad**: Funciona tanto con como sin personajes
+
+## Archivos Modificados
+- `/supabase/functions/generate-cover/index.ts`
+
+## Testing
+Para probar:
+1. Crear historia con personajes específicos
+2. Generar portada que mencione o incluya personajes
+3. Verificar que la portada refleje las características visuales de los personajes
+4. Comparar con comportamiento anterior
+
+## Compatibilidad
+- Mantiene compatibilidad con el parámetro `reference_image_ids` existente
+- Funcionará tanto con llamadas que incluyan URLs como con el nuevo sistema

--- a/docs/solutions/character-image-mapping/README.md
+++ b/docs/solutions/character-image-mapping/README.md
@@ -74,6 +74,11 @@ IMPORTANTE: Cuando el texto mencione a un personaje por su nombre, usa su imagen
 
 ## Archivos Modificados
 - `/supabase/functions/generate-image-pages/index.ts`
+- `/supabase/functions/generate-cover/index.ts` (extensión de la solución)
+- `/supabase/functions/_shared/openai.ts`
+
+## Extensión a generate-cover
+La misma solución se aplicó a `generate-cover` ya que tenía el mismo problema. Ver detalles en [EXTENSION-COVER.md](./EXTENSION-COVER.md).
 
 ## Testing
 Para probar la solución:


### PR DESCRIPTION
## Resumen
Extiende la solución del issue #247 a la función `generate-cover`, que tenía exactamente el mismo problema de asignación de imágenes de referencia a personajes.

## Problema Identificado
Después de resolver el issue #247 para `generate-image-pages`, se detectó que `generate-cover` tenía el mismo problema:
- **storyService.ts** obtenía URLs de thumbnails de personajes y las enviaba como `reference_image_ids`
- **generate-cover** recibía estas URLs pero NO los nombres de los personajes
- Sin nombres, no podía hacer asociación explícita imagen-personaje en el prompt

## Solución Implementada
1. **Nueva función especializada**: `generateCoverWithCharacters` para manejo de múltiples personajes en portadas
2. **Obtención directa de personajes**: Cambia de recibir URLs a obtener datos completos desde `story_characters`
3. **Prompt adaptado para portadas**: Contexto específico para generación de portadas con personajes
4. **Soporte completo para gpt-image-1**: Hasta 16 imágenes de referencia con mapeo explícito
5. **Compatibilidad mantenida**: Sigue funcionando con `reference_image_ids` existentes

## Diferencias con generate-image-pages
- **Contexto de prompt**: Adaptado para portadas vs. escenas narrativas
- **Uso opcional**: Los personajes en portadas son opcionales, no siempre necesarios
- **Estilo**: Enfocado en representación más estilizada de personajes

## Test plan
- [x] Verificar que el código compila sin errores
- [ ] Crear historia con 2-3 personajes específicos
- [ ] Generar portada que mencione o incluya personajes
- [ ] Verificar que la portada refleje características visuales de los personajes
- [ ] Comparar con comportamiento anterior

Related to #247

🤖 Generated with [Claude Code](https://claude.ai/code)