### PR TITLE
fix: Aumentar timeout del loader a 5 minutos

### DIFF
--- a/src/components/UI/Loader/OverlayLoader.tsx
+++ b/src/components/UI/Loader/OverlayLoader.tsx
@@ -18,8 +18,8 @@ export interface OverlayLoaderProps {
 }
 
 const MESSAGE_INTERVAL = 7000;
-const DEFAULT_TIMEOUT = 40000;
-const DEFAULT_FALLBACK_DELAY = 60000;
+const DEFAULT_TIMEOUT = 300000; // 5 minutos
+const DEFAULT_FALLBACK_DELAY = 360000; // 6 minutos
 
 const OverlayLoader: React.FC<OverlayLoaderProps> = ({
   etapa,


### PR DESCRIPTION
## 📝 Resumen
Aumenta el tiempo de espera antes de mostrar el mensaje "Esto está tardando más de lo esperado..." de 40 segundos a 5 minutos.

## 🎯 Motivación
El mensaje aparecía muy pronto (40 segundos) para procesos que normalmente pueden tomar más tiempo, generando ansiedad innecesaria en los usuarios.

## 🔧 Cambios
- **DEFAULT_TIMEOUT**: 40 segundos → **5 minutos** (300,000 ms)
- **DEFAULT_FALLBACK_DELAY**: 1 minuto → **6 minutos** (360,000 ms)

## 📊 Impacto
- Mejor experiencia de usuario en procesos largos
- Reduce la ansiedad al no mostrar el mensaje de demora tan pronto
- Los mensajes del loader siguen rotando cada 7 segundos
- El callback `onFallback` ahora se ejecuta después de 6 minutos

## 🧪 Testing
1. Iniciar cualquier proceso que use el OverlayLoader
2. Verificar que los mensajes rotan normalmente
3. Esperar 5 minutos para ver el mensaje "Esto está tardando más de lo esperado..."
4. Verificar que `onFallback` se ejecuta después de 6 minutos

## 📁 Archivos modificados
- `src/components/UI/Loader/OverlayLoader.tsx`

🤖 Generated with [Claude Code](https://claude.ai/code)