### PR TITLE
[auto][prioridad alta] Agregar etapas Diseño y Vista Previa a admin/flujo con contador de usuarios activos

### DIFF
--- a/src/constants/edgeFunctionColors.ts
+++ b/src/constants/edgeFunctionColors.ts
@@ -5,5 +5,7 @@ export const edgeFunctionColorMap: Record<string, { base: string; active: string
   'generate-image-pages': { base: 'bg-yellow-100 text-yellow-800', active: 'bg-yellow-600 text-white' },
   'describe-and-sketch': { base: 'bg-purple-100 text-purple-800', active: 'bg-purple-600 text-white' },
   'generate-cover-variant': { base: 'bg-teal-100 text-teal-800', active: 'bg-teal-600 text-white' },
-  'generate-thumbnail-variant': { base: 'bg-orange-100 text-orange-800', active: 'bg-orange-600 text-white' }
+  'generate-thumbnail-variant': { base: 'bg-orange-100 text-orange-800', active: 'bg-orange-600 text-white' },
+  'generate-illustration': { base: 'bg-indigo-100 text-indigo-800', active: 'bg-indigo-600 text-white' },
+  'story-export': { base: 'bg-red-100 text-red-800', active: 'bg-red-600 text-white' }
 };


### PR DESCRIPTION
## Summary
- Agregadas nuevas etapas **Diseño** y **Vista Previa** al panel admin/flujo
- Implementado contador de usuarios activos en la parte superior del dashboard
- Actualizados colores para las nuevas edge functions

## Cambios realizados

### 1. Nuevas Etapas en CONFIG
- **Diseño**: 
  - `generate-illustration` - Generar ilustración
  - `generate-image-pages` - Generar páginas
- **Vista Previa**:
  - `story-export` - Generar PDF

### 2. Contador de Usuarios Activos
- Muestra usuarios únicos que han ejecutado edge functions en los últimos 60 minutos
- Se actualiza automáticamente cada 10 segundos
- Diseño con gradiente purple-to-blue

### 3. Actualización de Colores
- `generate-illustration`: indigo (bg-indigo-100/600)
- `story-export`: red (bg-red-100/600)

## Test plan
- [x] Verificar que aparecen las nuevas etapas en admin/flujo
- [x] Confirmar que el contador de usuarios activos se muestra correctamente
- [x] Probar que los toggles funcionan para las nuevas etapas
- [x] Verificar que las métricas se cargan para las nuevas edge functions
- [x] Confirmar que los colores se aplican correctamente

Closes #255

🤖 Generated with [Claude Code](https://claude.ai/code)