### PR TITLE
feat: Bloquear edición de campos después de generar PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Feature: Bloqueo de Edición Post-PDF (2025-06-25)
+- **Nueva Funcionalidad**: Implementado sistema de bloqueo de edición de campos después de generar PDF
+  - **Hook personalizado**: `useStoryCompletionStatus` para monitorear estado de completación desde BD
+  - **DedicatoriaChoiceStep**: Botones "Sí/No" bloqueados con indicadores visuales cuando `story.status === 'completed'`
+  - **DedicatoriaStep**: Todos los campos de dedicatoria bloqueados (texto, imagen, configuración de layout)
+  - **PreviewStep**: Edición inline y modal avanzado deshabilitados, reemplazados con vista de solo lectura
+  - **UX mejorada**: Íconos de candado, mensajes explicativos y estilos visuales diferenciados
+  - **Real-time**: Escucha cambios de estado en tiempo real via Supabase subscriptions
+- **Impacto**: Evita inconsistencias entre PDF generado y contenido en interfaz, mejora confiabilidad del sistema
+- **Archivos**: `src/hooks/useStoryCompletionStatus.ts`, `src/components/Wizard/steps/DedicatoriaChoiceStep.tsx`, `src/components/Wizard/steps/DedicatoriaStep.tsx`, `src/components/Wizard/steps/PreviewStep.tsx`
+- **Issue**: #266
+
 ### Feature: Mejoras al Panel Admin/Flujo (2025-06-24)
 - **Nueva Funcionalidad**: Agregadas etapas faltantes Diseño y Vista Previa al panel de administración
   - **Etapa Diseño**: 

--- a/docs/solutions/bloqueo-edicion-post-pdf/README.md
+++ b/docs/solutions/bloqueo-edicion-post-pdf/README.md
@@ -1,0 +1,125 @@
+# Bloqueo de Edición de Campos Después de Generar PDF
+
+## 📋 Issues Resueltos
+- Issue #266: Bloquear edición de campos después de generar PDF
+
+## 🎯 Objetivo
+Implementar un sistema que bloquee la edición de todos los campos relacionados con dedicatoria y contenido del cuento una vez que se ha generado el PDF final (`story.status === 'completed'`). Esto evita inconsistencias entre el PDF generado y el contenido mostrado en la interfaz.
+
+## 📁 Archivos Modificados
+- `src/hooks/useStoryCompletionStatus.ts` - Hook personalizado para obtener y monitorear el estado de completación de la historia desde la base de datos
+- `src/components/Wizard/steps/DedicatoriaChoiceStep.tsx` - Bloqueo de botones de elección "Sí/No" para dedicatoria
+- `src/components/Wizard/steps/DedicatoriaStep.tsx` - Bloqueo de todos los campos de edición de dedicatoria (texto, imagen, configuración)
+- `src/components/Wizard/steps/PreviewStep.tsx` - Bloqueo de edición inline de texto y modal avanzado de edición
+
+## 🔧 Cambios Técnicos
+
+### Hook `useStoryCompletionStatus`
+```typescript
+// Nuevo hook para monitorear estado de completación
+export const useStoryCompletionStatus = () => {
+  const [isCompleted, setIsCompleted] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  
+  // Obtiene estado desde Supabase con escucha en tiempo real
+  useEffect(() => {
+    const subscription = supabase
+      .channel(`story-status-${storyId}`)
+      .on('postgres_changes', {...})
+      .subscribe();
+  }, [storyId, supabase]);
+  
+  return { isCompleted, isLoading };
+};
+```
+
+### DedicatoriaChoiceStep - Antes
+```typescript
+<button onClick={handleYes} className="...">
+  Sí, agregar dedicatoria
+</button>
+```
+
+### DedicatoriaChoiceStep - Después
+```typescript
+<button 
+  onClick={handleYes}
+  disabled={isCompleted || isLoading}
+  className={`... ${isCompleted ? 'cursor-not-allowed bg-gray-100' : '...'}`}
+>
+  {isCompleted ? <Lock /> : <Heart />}
+  {isCompleted ? 'Opción bloqueada' : 'Sí, agregar dedicatoria'}
+</button>
+```
+
+### DedicatoriaStep - Cambios Principales
+- **Textarea deshabilitado**: `disabled={isCompleted || isLoading}`
+- **Carga de imagen bloqueada**: Botón de upload reemplazado con ícono de candado
+- **Configuración de layout bloqueada**: Todos los botones de posición, tamaño y alineación deshabilitados
+- **Ejemplos no clickeables**: Botones de ejemplo ocultos cuando está completado
+
+### PreviewStep - Cambios Principales
+- **InlineTextEditor reemplazado** por div de solo lectura cuando `isCompleted === true`
+- **Modal avanzado bloqueado**: Función `handleAdvancedEdit` verifica estado antes de abrir
+- **Botón de edición**: Reemplazado con ícono de candado y cursor deshabilitado
+
+## 🧪 Testing
+
+### Manual
+- [x] **Flujo Normal**: Verificar que cuando `story.status !== 'completed'`, todos los campos son editables
+- [x] **Estado Completado**: Simular `story.status === 'completed'` y verificar bloqueos
+- [x] **Indicadores Visuales**: Confirmar que se muestran íconos de candado y mensajes explicativos
+- [x] **Navegación**: Verificar que la navegación entre páginas sigue funcionando
+- [x] **Vista Previa**: Confirmar que la vista previa de dedicatoria se mantiene funcional
+
+### Automatizado
+- [ ] `npm run cypress:run` - Tests existentes deben pasar (fallan por problemas preexistentes de auth)
+- [x] `npm run lint` - Código pasa linting (con warnings menores preexistentes)
+- [x] `npm run dev` - Aplicación se levanta correctamente
+
+### Escenarios de Prueba
+1. **Historia en progreso**: Todos los campos editables, sin restricciones
+2. **Historia completada**: Todos los campos bloqueados, indicadores visuales activos
+3. **Cambio en tiempo real**: Si el estado cambia mientras el usuario está en la página
+
+## 🚀 Deployment
+
+### Requisitos
+- [x] Hook `useStoryCompletionStatus` implementado
+- [x] Integración con Supabase real-time subscriptions
+- [x] Compatibilidad con tema claro/oscuro existente
+
+### Pasos
+1. **Merge a main**: Los cambios son seguros, no afectan funcionalidad existente
+2. **Verificación**: Confirmar que historias existentes siguen funcionando normalmente
+3. **Test de completación**: Verificar que al generar PDF se bloquean los campos correctamente
+
+## 📊 Monitoreo
+
+### Métricas a Observar
+- **Funcionalidad de edición**: Asegurarse que usuarios puedan editar normalmente antes de generar PDF
+- **Consistencia de datos**: Verificar que no hay discrepancias entre PDF y contenido en BD
+- **UX**: Monitorear feedback sobre claridad de los mensajes de bloqueo
+
+### Posibles Regresiones
+- **Edición normal**: Vigilar que usuarios puedan editar sin problemas en historias no completadas
+- **Performance**: El hook hace consultas adicionales a BD, monitorear impacto
+- **Real-time updates**: Verificar que los cambios de estado se reflejen inmediatamente
+
+## 🎨 Consideraciones de UX
+
+### Indicadores Visuales
+- **Íconos de candado**: Reemplazan íconos originales cuando está bloqueado
+- **Colores atenuados**: Grises para indicar campos deshabilitados
+- **Mensajes explicativos**: Banners amarillos con explicación clara del bloqueo
+- **Tooltips informativos**: Hover states que explican por qué está bloqueado
+
+### Flujo de Usuario
+- **Transparencia**: Usuario entiende claramente por qué no puede editar
+- **Consistencia**: Mismo patrón visual en todos los pasos afectados
+- **Reversibilidad**: Si se implementa "editar nueva versión", este sistema lo soporta
+
+## 🔗 Referencias
+- Issue #266: https://github.com/Customware-cl/Lacuenteria/issues/266
+- Documentación de Supabase Real-time: https://supabase.com/docs/guides/realtime
+- Patrón de diseño para estados bloqueados en la aplicación

--- a/src/components/Wizard/steps/DedicatoriaChoiceStep.tsx
+++ b/src/components/Wizard/steps/DedicatoriaChoiceStep.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
-import { Heart, ArrowRight } from 'lucide-react';
+import { Heart, ArrowRight, Lock } from 'lucide-react';
 import { useWizard } from '../../../context/WizardContext';
 import { useWizardFlowStore } from '../../../stores/wizardFlowStore';
 import { useParams } from 'react-router-dom';
 import { storyService } from '../../../services/storyService';
 import { useNotifications } from '../../../hooks/useNotifications';
 import { NotificationType, NotificationPriority } from '../../../types/notification';
+import { useStoryCompletionStatus } from '../../../hooks/useStoryCompletionStatus';
 
 const DedicatoriaChoiceStep: React.FC = () => {
-  const { setCurrentStep, nextStep, skipToStep } = useWizard();
+  const { nextStep, skipToStep } = useWizard();
   const { avanzarEtapa } = useWizardFlowStore();
   const { storyId } = useParams();
   const { createNotification } = useNotifications();
+  const { isCompleted, isLoading } = useStoryCompletionStatus();
 
   const handleYes = async () => {
     // Persistir elección en BD
@@ -66,64 +68,103 @@ const DedicatoriaChoiceStep: React.FC = () => {
     <div className="max-w-2xl mx-auto text-center py-12">
       <div className="mb-8">
         <div className="inline-flex items-center justify-center w-20 h-20 bg-purple-100 dark:bg-purple-900/30 rounded-full mb-6">
-          <Heart className="w-10 h-10 text-purple-600 dark:text-purple-400" />
+          {isCompleted ? (
+            <Lock className="w-10 h-10 text-gray-500 dark:text-gray-400" />
+          ) : (
+            <Heart className="w-10 h-10 text-purple-600 dark:text-purple-400" />
+          )}
         </div>
         
         <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">
-          ¿Te gustaría agregar una dedicatoria?
+          {isCompleted ? 'Dedicatoria - Solo Lectura' : '¿Te gustaría agregar una dedicatoria?'}
         </h2>
         
-        <p className="text-lg text-gray-600 dark:text-gray-400 mb-2">
-          Personaliza tu cuento con un mensaje especial
-        </p>
-        
-        <p className="text-sm text-gray-500 dark:text-gray-500">
-          Puedes incluir texto personalizado y/o una imagen para hacer tu cuento aún más único
-        </p>
+        {isCompleted ? (
+          <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4 mb-6">
+            <div className="flex items-center justify-center gap-2 text-yellow-800 dark:text-yellow-200">
+              <Lock className="w-5 h-5" />
+              <span className="font-medium">PDF generado - edición bloqueada</span>
+            </div>
+            <p className="text-sm text-yellow-700 dark:text-yellow-300 mt-2">
+              Esta opción ya no puede modificarse porque el cuento ha sido finalizado y exportado
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="text-lg text-gray-600 dark:text-gray-400 mb-2">
+              Personaliza tu cuento con un mensaje especial
+            </p>
+            
+            <p className="text-sm text-gray-500 dark:text-gray-500">
+              Puedes incluir texto personalizado y/o una imagen para hacer tu cuento aún más único
+            </p>
+          </>
+        )}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-lg mx-auto">
         <button
           onClick={handleYes}
-          className="group relative overflow-hidden rounded-xl border-2 border-purple-300 dark:border-purple-600 p-6 
-                     hover:border-purple-400 dark:hover:border-purple-500 transition-all duration-300
-                     hover:shadow-lg hover:scale-105 bg-white dark:bg-gray-800"
+          disabled={isCompleted || isLoading}
+          className={`group relative overflow-hidden rounded-xl border-2 p-6 transition-all duration-300
+                     ${isCompleted || isLoading 
+                       ? 'border-gray-300 dark:border-gray-600 cursor-not-allowed bg-gray-100 dark:bg-gray-700' 
+                       : 'border-purple-300 dark:border-purple-600 hover:border-purple-400 dark:hover:border-purple-500 hover:shadow-lg hover:scale-105 bg-white dark:bg-gray-800'
+                     }`}
         >
           <div className="relative z-10">
-            <Heart className="w-8 h-8 text-purple-600 dark:text-purple-400 mx-auto mb-3" />
-            <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+            {isCompleted ? (
+              <Lock className={`w-8 h-8 mx-auto mb-3 ${isCompleted ? 'text-gray-400' : 'text-purple-600 dark:text-purple-400'}`} />
+            ) : (
+              <Heart className="w-8 h-8 text-purple-600 dark:text-purple-400 mx-auto mb-3" />
+            )}
+            <h3 className={`font-semibold mb-1 ${isCompleted ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-gray-100'}`}>
               Sí, agregar dedicatoria
             </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Personaliza con un mensaje especial
+            <p className={`text-sm ${isCompleted ? 'text-gray-400 dark:text-gray-500' : 'text-gray-600 dark:text-gray-400'}`}>
+              {isCompleted ? 'Opción bloqueada' : 'Personaliza con un mensaje especial'}
             </p>
           </div>
-          <div className="absolute inset-0 bg-gradient-to-br from-purple-50 to-pink-50 dark:from-purple-900/20 dark:to-pink-900/20 
-                          opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+          {!isCompleted && (
+            <div className="absolute inset-0 bg-gradient-to-br from-purple-50 to-pink-50 dark:from-purple-900/20 dark:to-pink-900/20 
+                            opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+          )}
         </button>
 
         <button
           onClick={handleNo}
-          className="group relative overflow-hidden rounded-xl border-2 border-gray-300 dark:border-gray-600 p-6 
-                     hover:border-gray-400 dark:hover:border-gray-500 transition-all duration-300
-                     hover:shadow-lg hover:scale-105 bg-white dark:bg-gray-800"
+          disabled={isCompleted || isLoading}
+          className={`group relative overflow-hidden rounded-xl border-2 p-6 transition-all duration-300
+                     ${isCompleted || isLoading 
+                       ? 'border-gray-300 dark:border-gray-600 cursor-not-allowed bg-gray-100 dark:bg-gray-700' 
+                       : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 hover:shadow-lg hover:scale-105 bg-white dark:bg-gray-800'
+                     }`}
         >
           <div className="relative z-10">
-            <ArrowRight className="w-8 h-8 text-gray-600 dark:text-gray-400 mx-auto mb-3" />
-            <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-1">
+            {isCompleted ? (
+              <Lock className={`w-8 h-8 mx-auto mb-3 ${isCompleted ? 'text-gray-400' : 'text-gray-600 dark:text-gray-400'}`} />
+            ) : (
+              <ArrowRight className="w-8 h-8 text-gray-600 dark:text-gray-400 mx-auto mb-3" />
+            )}
+            <h3 className={`font-semibold mb-1 ${isCompleted ? 'text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-gray-100'}`}>
               No, continuar
             </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Ir directamente a la descarga
+            <p className={`text-sm ${isCompleted ? 'text-gray-400 dark:text-gray-500' : 'text-gray-600 dark:text-gray-400'}`}>
+              {isCompleted ? 'Opción bloqueada' : 'Ir directamente a la descarga'}
             </p>
           </div>
-          <div className="absolute inset-0 bg-gray-50 dark:bg-gray-700/20 
-                          opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+          {!isCompleted && (
+            <div className="absolute inset-0 bg-gray-50 dark:bg-gray-700/20 
+                            opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+          )}
         </button>
       </div>
 
       <p className="text-xs text-gray-500 dark:text-gray-400 mt-8">
-        Siempre podrás editar tu cuento más tarde si cambias de opinión
+        {isCompleted 
+          ? 'Esta selección ya no puede modificarse una vez que el PDF ha sido generado'
+          : 'Siempre podrás editar tu cuento más tarde si cambias de opinión'
+        }
       </p>
     </div>
   );

--- a/src/hooks/useStoryCompletionStatus.ts
+++ b/src/hooks/useStoryCompletionStatus.ts
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useParams } from 'react-router-dom';
+
+export const useStoryCompletionStatus = () => {
+  const [isCompleted, setIsCompleted] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const { supabase } = useAuth();
+  const { storyId } = useParams();
+
+  useEffect(() => {
+    if (!storyId) {
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchStoryStatus = async () => {
+      try {
+        setIsLoading(true);
+        
+        const { data: story, error } = await supabase
+          .from('stories')
+          .select('status')
+          .eq('id', storyId)
+          .single();
+
+        if (error) {
+          console.error('[useStoryCompletionStatus] Error fetching story status:', error);
+          setIsCompleted(false);
+        } else {
+          setIsCompleted(story?.status === 'completed');
+        }
+      } catch (error) {
+        console.error('[useStoryCompletionStatus] Error:', error);
+        setIsCompleted(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchStoryStatus();
+
+    // Escuchar cambios en tiempo real
+    const subscription = supabase
+      .channel(`story-status-${storyId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'stories',
+          filter: `id=eq.${storyId}`,
+        },
+        (payload) => {
+          if (payload.new && 'status' in payload.new) {
+            setIsCompleted(payload.new.status === 'completed');
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [storyId, supabase]);
+
+  return {
+    isCompleted,
+    isLoading
+  };
+};


### PR DESCRIPTION
## Summary
Implementa un sistema completo de bloqueo de edición de campos una vez que se ha generado el PDF del cuento (`story.status === 'completed'`), evitando inconsistencias entre el contenido exportado y lo mostrado en la interfaz.

## Características Implementadas

### 🔒 Sistema de Bloqueo
- **Hook personalizado** `useStoryCompletionStatus` que monitorea el estado de completación desde la base de datos con actualizaciones en tiempo real
- **Bloqueo en DedicatoriaChoiceStep**: Botones "Sí/No" deshabilitados con indicadores visuales
- **Bloqueo en DedicatoriaStep**: Todos los campos de dedicatoria bloqueados (texto, imagen, configuración de layout)
- **Bloqueo en PreviewStep**: Edición inline reemplazada por vista de solo lectura, modal avanzado bloqueado

### 🎨 UX Mejorada
- **Indicadores visuales claros**: Íconos de candado, colores atenuados, cursor deshabilitado
- **Mensajes explicativos**: Banners informativos que explican por qué está bloqueado
- **Consistencia**: Mismo patrón visual en todos los pasos afectados
- **Navegación preservada**: La navegación entre páginas sigue funcionando normalmente

### ⚡ Características Técnicas
- **Real-time monitoring**: Subscripción a cambios de estado via Supabase
- **Performance optimizada**: Hook eficiente que solo consulta cuando es necesario
- **Compatibilidad completa**: Funciona con tema claro/oscuro existente
- **No-breaking changes**: Funcionalidad existente se mantiene intacta

## Test plan
- [x] Verificar que campos son editables normalmente cuando `story.status \!== 'completed'`
- [x] Confirmar bloqueo completo cuando `story.status === 'completed'`  
- [x] Validar indicadores visuales y mensajes explicativos
- [x] Verificar que navegación y vista previa siguen funcionando
- [x] Confirmar compatibilidad con tema claro/oscuro
- [x] Ejecutar `npm run lint` (código pasa linting)
- [x] Ejecutar `npm run dev` (aplicación se levanta correctamente)

## Archivos Modificados
- `src/hooks/useStoryCompletionStatus.ts` - Nuevo hook para monitoreo de estado
- `src/components/Wizard/steps/DedicatoriaChoiceStep.tsx` - Bloqueo de botones de elección
- `src/components/Wizard/steps/DedicatoriaStep.tsx` - Bloqueo de campos de dedicatoria
- `src/components/Wizard/steps/PreviewStep.tsx` - Bloqueo de edición de contenido
- `docs/solutions/bloqueo-edicion-post-pdf/README.md` - Documentación completa
- `CHANGELOG.md` - Registro de cambios

## Resolves
Closes #266

🤖 Generated with [Claude Code](https://claude.ai/code)