### PR TITLE
fix: Agregar filtro explícito por usuario en Mis cuentos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fix: Filtro de usuario en "Mis cuentos" (2025-06-28)
+- **Problema**: La página "Mis cuentos" no filtraba explícitamente por usuario, permitiendo que usuarios con roles admin/operator vean cuentos de otros usuarios
+- **Solución**: Agregado filtro explícito `.eq('user_id', user?.id)` en la consulta de MyStories.tsx
+- **Beneficio**: Garantiza que cada usuario solo vea sus propios cuentos, independientemente de sus roles
+
 ### Feature: Sistema Robusto de Roles de Usuario (2025-06-27)
 - **Reemplazo de emails hardcodeados**: Sistema escalable de roles admin/operator/user
 - **Base de Datos**:

--- a/docs/solutions/mis-cuentos-filtro-usuario/README.md
+++ b/docs/solutions/mis-cuentos-filtro-usuario/README.md
@@ -1,0 +1,47 @@
+# Solución: Filtro de usuario en "Mis cuentos"
+
+## Problema
+
+La página "Mis cuentos" no estaba filtrando explícitamente los cuentos por usuario en la consulta a la base de datos. Aunque las políticas RLS (Row Level Security) de Supabase deberían aplicarse automáticamente, existía una política adicional que permite a usuarios con roles admin/operator ver todos los cuentos completados, lo que podría causar que estos usuarios vean cuentos de otros usuarios en su vista personal de "Mis cuentos".
+
+## Análisis
+
+### Consulta original
+```typescript
+const { data, error } = await supabase
+  .from('stories')
+  .select('*')
+  .order('created_at', { ascending: false });
+```
+
+### Políticas RLS existentes
+1. **"Users can read own stories"**: Permite que cada usuario vea solo sus propios cuentos
+2. **"Admins and operators can view completed stories"**: Permite que admins/operadores vean TODOS los cuentos completados (para el panel de gestión de pedidos)
+
+El problema surgía porque la segunda política podría tener precedencia sobre la primera en ciertos casos, permitiendo que usuarios con permisos administrativos vean cuentos de otros usuarios en su vista personal.
+
+## Solución implementada
+
+Se modificó la consulta en `MyStories.tsx` para incluir un filtro explícito por `user_id`:
+
+```typescript
+const { data, error } = await supabase
+  .from('stories')
+  .select('*')
+  .eq('user_id', user?.id)  // Filtro explícito agregado
+  .order('created_at', { ascending: false });
+```
+
+## Beneficios
+
+1. **Seguridad mejorada**: Garantiza que cada usuario solo vea sus propios cuentos, independientemente de sus roles o permisos
+2. **Comportamiento consistente**: La vista "Mis cuentos" funciona igual para todos los usuarios
+3. **Separación clara**: Mantiene la separación entre la vista personal ("Mis cuentos") y la vista administrativa (panel de pedidos)
+
+## Archivos modificados
+
+- `/src/pages/MyStories.tsx` - Línea 92: Agregado filtro `.eq('user_id', user?.id)`
+
+## Fecha de implementación
+
+28 de junio de 2025

--- a/src/pages/MyStories.tsx
+++ b/src/pages/MyStories.tsx
@@ -89,6 +89,7 @@ const MyStories: React.FC = () => {
       const { data, error } = await supabase
         .from('stories')
         .select('*')
+        .eq('user_id', user?.id)
         .order('created_at', { ascending: false });
 
       if (error) throw error;


### PR DESCRIPTION
## Resumen

Este PR corrige un problema donde usuarios con roles admin/operator podían ver cuentos de otros usuarios en la página "Mis cuentos".

## Problema

La consulta en `MyStories.tsx` no filtraba explícitamente por usuario. Aunque las políticas RLS deberían aplicarse automáticamente, existe una política que permite a admins/operators ver todos los cuentos completados (para el panel de pedidos), lo que causaba que estos usuarios vean cuentos ajenos en su vista personal.

## Solución

Se agregó un filtro explícito `.eq('user_id', user?.id)` en la consulta para garantizar que cada usuario solo vea sus propios cuentos, independientemente de sus roles.

## Cambios

- ✅ `src/pages/MyStories.tsx`: Agregado filtro por user_id en línea 92
- 📝 Documentación creada en `/docs/solutions/mis-cuentos-filtro-usuario/`
- 📋 CHANGELOG.md actualizado

## Test plan

1. Iniciar sesión como usuario regular → Solo debe ver sus propios cuentos
2. Iniciar sesión como admin/operator → Solo debe ver sus propios cuentos en "Mis cuentos"
3. Verificar que el panel admin de pedidos siga funcionando correctamente

🤖 Generated with [Claude Code](https://claude.ai/code)