### PR TITLE
fix: Corregir error 'Bucket not found' en generación de PDF

### DIFF
--- a/supabase/migrations/20250701212500_ensure_exports_bucket_exists.sql
+++ b/supabase/migrations/20250701212500_ensure_exports_bucket_exists.sql
@@ -8,7 +8,7 @@ BEGIN
   VALUES ('exports', 'exports', true)
   ON CONFLICT (id) DO NOTHING;
   
-  -- Create RLS policy for exports bucket - users can read their own exports
+  -- Create RLS policy for exports bucket - users can read their own exports, admins and operators can read all
   IF NOT EXISTS (
     SELECT 1 FROM pg_policies 
     WHERE tablename = 'objects' 
@@ -19,7 +19,12 @@ BEGIN
       ON storage.objects
       FOR SELECT
       TO authenticated
-      USING (bucket_id = 'exports' AND (storage.foldername(name))[1] = auth.uid()::text);
+      USING (
+        bucket_id = 'exports' AND (
+          (storage.foldername(name))[1] = auth.uid()::text OR
+          has_permission('orders.view')
+        )
+      );
   END IF;
   
   -- Create RLS policy for exports bucket - service role can insert exports

--- a/supabase/migrations/20250701212500_ensure_exports_bucket_exists.sql
+++ b/supabase/migrations/20250701212500_ensure_exports_bucket_exists.sql
@@ -1,0 +1,54 @@
+-- Ensure exports bucket exists for PDF generation
+-- Fixes "Bucket not found" error in story-export function
+
+DO $$ 
+BEGIN
+  -- Create exports bucket if it doesn't exist
+  INSERT INTO storage.buckets (id, name, public)
+  VALUES ('exports', 'exports', true)
+  ON CONFLICT (id) DO NOTHING;
+  
+  -- Create RLS policy for exports bucket - users can read their own exports
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE tablename = 'objects' 
+    AND schemaname = 'storage'
+    AND policyname = 'Users can read own exports'
+  ) THEN
+    CREATE POLICY "Users can read own exports"
+      ON storage.objects
+      FOR SELECT
+      TO authenticated
+      USING (bucket_id = 'exports' AND (storage.foldername(name))[1] = auth.uid()::text);
+  END IF;
+  
+  -- Create RLS policy for exports bucket - service role can insert exports
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE tablename = 'objects' 
+    AND schemaname = 'storage'
+    AND policyname = 'Service role can insert exports'
+  ) THEN
+    CREATE POLICY "Service role can insert exports"
+      ON storage.objects
+      FOR INSERT
+      TO service_role
+      WITH CHECK (bucket_id = 'exports');
+  END IF;
+  
+  -- Create RLS policy for exports bucket - authenticated users can insert in their own folder
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies 
+    WHERE tablename = 'objects' 
+    AND schemaname = 'storage'
+    AND policyname = 'Users can insert own exports'
+  ) THEN
+    CREATE POLICY "Users can insert own exports"
+      ON storage.objects
+      FOR INSERT
+      TO authenticated
+      WITH CHECK (bucket_id = 'exports' AND (storage.foldername(name))[1] = auth.uid()::text);
+  END IF;
+  
+  RAISE NOTICE 'Exports bucket configuration completed successfully';
+END $$;


### PR DESCRIPTION
## Resumen
Corrige el error `statusCode "404", error "Bucket not found"` que aparece al generar PDFs de cuentos.

## Cambios
- ✅ Migración con nomenclatura correcta `20250701212500_ensure_exports_bucket_exists.sql`
- ✅ Creación automática del bucket `exports` si no existe
- ✅ Políticas RLS apropiadas para el bucket
- ✅ Manejo idempotente con `ON CONFLICT DO NOTHING`

## Test plan
- [ ] Ejecutar migración en producción
- [ ] Verificar generación de PDF funciona correctamente
- [ ] Confirmar que bucket `exports` existe en Supabase Storage

🤖 Generated with [Claude Code](https://claude.ai/code)